### PR TITLE
Improve release notes generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,7 @@ release:
   before_script:
     - export PATH="/opt/homebrew/bin:$PATH"
     - brew install gon goreleaser wget
+    - git remote set-url origin https://github.com/platformsh/cli
   script:
     - make release
   dependencies:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,11 +55,7 @@ snapshot:
 
 changelog:
   sort: asc
-  use: github
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native
 
 universal_binaries:
   - id: platform-macos


### PR DESCRIPTION
* Use `github-native` release notes generation which is cleaner
* Set the `origin` URL to GitHub so that Go Releaser correctly understands the repository owner and name
   Extracting repository information is based on the current remote of the Git repository[^1]

[^1]: https://github.com/goreleaser/goreleaser/blob/0f8de794738528d03af849e35c4d5199c948211e/internal/git/config.go#L16-L26