### PR TITLE
Patch the list command to include the new Platformify command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,5 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,4 +150,4 @@ run:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly

--- a/commands/list.go
+++ b/commands/list.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/platformsh/cli/internal/legacy"
+)
+
+func init() {
+	RootCmd.AddCommand(ListCmd)
+}
+
+func init() {
+	ListCmd.Flags().String("format", "txt", "The output format (txt, json, or md) [default: \"txt\"]")
+	ListCmd.Flags().Bool("raw", false, "To output raw command list")
+	ListCmd.Flags().Bool("all", false, "Show all commands, including hidden ones")
+
+	viper.BindPFlags(ListCmd.Flags()) //nolint:errcheck
+}
+
+var ListCmd = &cobra.Command{
+	Use:   "list [flags] [namespace]",
+	Short: "Lists commands",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var b bytes.Buffer
+		c := &legacy.CLIWrapper{
+			Version:          version,
+			CustomPshCliPath: viper.GetString("phar-path"),
+			Debug:            viper.GetBool("debug"),
+			Stdout:           &b,
+			Stderr:           cmd.ErrOrStderr(),
+			Stdin:            cmd.InOrStdin(),
+		}
+		if err := c.Init(); err != nil {
+			debugLog("%s\n", color.RedString(err.Error()))
+			os.Exit(1)
+			return
+		}
+
+		arguments := []string{"list", "--format=json"}
+		if viper.GetBool("all") {
+			arguments = append(arguments, "--all")
+		}
+		if len(args) > 0 {
+			arguments = append(arguments, args[0])
+		}
+		if err := c.Exec(cmd.Context(), arguments...); err != nil {
+			debugLog("%s\n", color.RedString(err.Error()))
+			exitCode := 1
+			var execErr *exec.ExitError
+			if errors.As(err, &execErr) {
+				exitCode = execErr.ExitCode()
+			}
+			//nolint:errcheck
+			c.Cleanup()
+			os.Exit(exitCode)
+			return
+		}
+
+		var list List
+		if err := json.Unmarshal(b.Bytes(), &list); err != nil {
+			debugLog("%s\n", color.RedString(err.Error()))
+			os.Exit(1)
+			return
+		}
+
+		if !list.DescribesNamespace() || list.Namespace == ProjectInitCommand.Name.Namespace {
+			list.AddCommand(&ProjectInitCommand)
+		}
+
+		format := viper.GetString("format")
+		raw := viper.GetBool("raw")
+
+		var formatter Formatter[*List]
+		switch format {
+		case "json":
+			formatter = &JSONListFormatter{}
+		case "md":
+			formatter = &MDListFormatter{}
+		case "txt":
+			if raw {
+				formatter = &RawListFormatter{}
+			} else {
+				formatter = &TXTListFormatter{}
+			}
+		default:
+			c.Stdout = cmd.OutOrStdout()
+			arguments := []string{"list", "--format=" + format}
+			if err := c.Exec(cmd.Context(), arguments...); err != nil {
+				debugLog("%s\n", color.RedString(err.Error()))
+				exitCode := 1
+				var execErr *exec.ExitError
+				if errors.As(err, &execErr) {
+					exitCode = execErr.ExitCode()
+				}
+				//nolint:errcheck
+				c.Cleanup()
+				os.Exit(exitCode)
+			}
+			return
+		}
+
+		result, err := formatter.Format(&list)
+		if err != nil {
+			debugLog("%s\n", color.RedString(err.Error()))
+			os.Exit(1)
+			return
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), string(result))
+	},
+}

--- a/commands/list_formatters.go
+++ b/commands/list_formatters.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/fatih/color"
+
+	"github.com/platformsh/cli/internal/md"
+)
+
+type Formatter[T any] interface {
+	Format(T) ([]byte, error)
+}
+
+type JSONListFormatter struct{}
+
+func (f *JSONListFormatter) Format(list *List) ([]byte, error) {
+	buff := new(bytes.Buffer)
+	encoder := json.NewEncoder(buff)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(list)
+	return buff.Bytes(), err
+}
+
+type TXTListFormatter struct{}
+
+func (f *TXTListFormatter) Format(list *List) ([]byte, error) {
+	var b bytes.Buffer
+	writer := tabwriter.NewWriter(&b, 0, 8, 1, ' ', 0)
+	fmt.Fprintf(writer, "%s %s\n", list.Application.Name, color.GreenString(list.Application.Version))
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer, color.YellowString("Global options:"))
+	for _, opt := range GlobalOptions {
+		shortcut := opt.Shortcut
+		if shortcut == "" {
+			shortcut = "  "
+		}
+		fmt.Fprintf(writer, "  %s\t%s %s\n", color.GreenString(opt.Name), color.GreenString(shortcut), opt.Description)
+	}
+	fmt.Fprintln(writer)
+
+	writer.Init(&b, 0, 8, 4, ' ', 0)
+	if list.DescribesNamespace() {
+		fmt.Fprintln(writer, color.YellowString("Available commands for the \"%s\" namespace:", list.Namespace))
+	} else {
+		fmt.Fprintln(writer, color.YellowString("Available commands:"))
+	}
+
+	cmds := make(map[string][]Command)
+	for _, cmd := range list.Commands {
+		cmds[cmd.Name.Namespace] = append(cmds[cmd.Name.Namespace], cmd)
+	}
+
+	namespaces := make([]string, 0, len(cmds))
+	for namespace := range cmds {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+
+	for _, namespace := range namespaces {
+		if !list.DescribesNamespace() && namespace != "" {
+			fmt.Fprintln(writer, color.YellowString("%s\t", namespace))
+		}
+		for _, cmd := range cmds[namespace] {
+			name := color.GreenString(cmd.Name.String())
+			if len(cmd.Usage) > 1 {
+				name = name + " (" + strings.Join(cmd.Usage[1:], ", ") + ")"
+			}
+			fmt.Fprintf(writer, "  %s\t%s\n", name, cmd.Description.String())
+		}
+	}
+	writer.Flush()
+
+	return b.Bytes(), nil
+}
+
+type RawListFormatter struct{}
+
+func (f *RawListFormatter) Format(list *List) ([]byte, error) {
+	var b bytes.Buffer
+	writer := tabwriter.NewWriter(&b, 0, 8, 16, ' ', 0)
+	for _, cmd := range list.Commands {
+		fmt.Fprintf(writer, "%s\t%s\n", cmd.Name.String(), cmd.Description.String())
+	}
+	writer.Flush()
+
+	return b.Bytes(), nil
+}
+
+type MDListFormatter struct{}
+
+func (f *MDListFormatter) Format(list *List) ([]byte, error) {
+	b := md.NewBuilder()
+	b.H1(list.Application.Name + " " + list.Application.Version)
+
+	cmds := make(map[string][]Command)
+	for _, cmd := range list.Commands {
+		cmds[cmd.Name.Namespace] = append(cmds[cmd.Name.Namespace], cmd)
+	}
+
+	namespaces := make([]string, 0, len(cmds))
+	for namespace := range cmds {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+
+	for _, namespace := range namespaces {
+		if namespace != "" {
+			b.Paragraph(md.Bold(namespace)).Ln()
+		}
+		for _, cmd := range cmds[namespace] {
+			b.ListItem(md.Link(md.Code(cmd.Name.String()), md.Anchor(cmd.Name.String())))
+		}
+		b.Ln()
+	}
+
+	for _, cmd := range list.Commands {
+		b.H2(md.Code(cmd.Name.String()))
+		b.Paragraph(cmd.Description.String()).Ln()
+
+		if len(cmd.Usage) > 1 {
+			aliases := make([]string, 0, len(cmd.Usage[1:]))
+			for _, alias := range cmd.Usage[1:] {
+				aliases = append(aliases, md.Code(alias))
+			}
+			b.Paragraph("Aliases: " + strings.Join(aliases, ", ")).Ln()
+		}
+
+		b.H3("Usage")
+		if len(cmd.Usage[0]) > 0 {
+			b.CodeBlock(cmd.Usage[0])
+		}
+		b.Ln()
+
+		if cmd.Help != "" {
+			b.Paragraph(cmd.Help.String()).Ln()
+		}
+
+		if cmd.Definition.Arguments != nil && cmd.Definition.Arguments.Len() > 0 {
+			b.H3("Arguments")
+			for pair := cmd.Definition.Arguments.Oldest(); pair != nil; pair = pair.Next() {
+				arg := pair.Value
+				line := md.Code(arg.Name)
+				opts := make([]string, 0, 2)
+				if arg.IsRequired {
+					opts = append(opts, "required")
+				} else {
+					opts = append(opts, "optional")
+				}
+				if arg.IsArray {
+					opts = append(opts, "multiple values allowed")
+				}
+				line += "(" + strings.Join(opts, "; ") + ")"
+
+				b.ListItem(line)
+				if arg.Description != "" {
+					b.Paragraph("  " + arg.Description.String()).Ln()
+				}
+			}
+		}
+
+		b.H3("Options")
+		for pair := cmd.Definition.Options.Oldest(); pair != nil; pair = pair.Next() {
+			opt := pair.Value
+			line := md.Code(opt.Name)
+			if opt.Shortcut != "" {
+				line += " (" + md.Code(opt.Shortcut) + ")"
+			}
+			if opt.AcceptValue {
+				line += " (expects a value)"
+			}
+			b.ListItem(line)
+			if opt.Description != "" {
+				b.Paragraph("  " + opt.Description.String())
+			}
+		}
+	}
+
+	return []byte(b.String()), nil
+}

--- a/commands/list_input_options.go
+++ b/commands/list_input_options.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"github.com/fatih/color"
+)
+
+var (
+	HelpOption = Option{
+		Name:            "--help",
+		Shortcut:        "-h",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Display this help message",
+		Default:         Any{false},
+		Hidden:          false,
+	}
+	VerboseOption = Option{
+		Name:            "--verbose",
+		Shortcut:        "-v|vv|vvv",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Increase the verbosity of messages",
+		Default:         Any{false},
+		Hidden:          false,
+	}
+	VersionOption = Option{
+		Name:            "--version",
+		Shortcut:        "-V",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Display this application version",
+		Default:         Any{false},
+		Hidden:          false,
+	}
+	YesOption = Option{
+		Name:            "--yes",
+		Shortcut:        "-y",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description: "Answer \"yes\" to confirmation questions; " +
+			"accept the default value for other questions; disable interaction",
+		Default: Any{false},
+		Hidden:  false,
+	}
+	NoInteractionOption = Option{
+		Name:            "--no-interaction",
+		Shortcut:        "",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description: CleanString("Do not ask any interactive questions; accept default values. " +
+			"Equivalent to using the environment variable: " + color.YellowString("PLATFORMSH_CLI_NO_INTERACTION=1")),
+		Default: Any{false},
+		Hidden:  false,
+	}
+	AnsiOption = Option{
+		Name:            "--ansi",
+		Shortcut:        "",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Force ANSI output",
+		Default:         Any{false},
+		Hidden:          true,
+	}
+	NoAnsiOption = Option{
+		Name:            "--no-ansi",
+		Shortcut:        "",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Disable ANSI output",
+		Default:         Any{false},
+		Hidden:          true,
+	}
+	NoOption = Option{
+		Name:            "--no",
+		Shortcut:        "-n",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description: "Answer \"no\" to confirmation questions; " +
+			"accept the default value for other questions; disable interaction",
+		Default: Any{false},
+		Hidden:  true,
+	}
+	QuietOption = Option{
+		Name:            "--quiet",
+		Shortcut:        "-q",
+		AcceptValue:     false,
+		IsValueRequired: false,
+		IsMultiple:      false,
+		Description:     "Do not output any message",
+		Default:         Any{false},
+		Hidden:          true,
+	}
+)
+
+var (
+	GlobalOptions = []Option{
+		HelpOption,
+		VerboseOption,
+		VersionOption,
+		YesOption,
+		NoInteractionOption,
+		AnsiOption,
+		NoAnsiOption,
+		NoOption,
+		QuietOption,
+	}
+)

--- a/commands/list_models.go
+++ b/commands/list_models.go
@@ -1,0 +1,278 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+var (
+	ProjectInitCommand = Command{
+		Name: CommandName{
+			Namespace: "project",
+			Command:   "init",
+		},
+		Usage: []string{
+			"platform project:init",
+			"ify",
+		},
+		Description: "Initialize a project",
+		Help:        "",
+		Definition: Definition{
+			Arguments: &orderedmap.OrderedMap[string, Argument]{},
+			Options: orderedmap.New[string, Option](orderedmap.WithInitialData[string, Option](
+				orderedmap.Pair[string, Option]{
+					Key:   HelpOption.GetName(),
+					Value: HelpOption,
+				},
+				orderedmap.Pair[string, Option]{
+					Key:   VerboseOption.GetName(),
+					Value: VerboseOption,
+				},
+				orderedmap.Pair[string, Option]{
+					Key:   VersionOption.GetName(),
+					Value: VersionOption,
+				},
+				orderedmap.Pair[string, Option]{
+					Key:   YesOption.GetName(),
+					Value: YesOption,
+				},
+				orderedmap.Pair[string, Option]{
+					Key:   NoInteractionOption.GetName(),
+					Value: NoInteractionOption,
+				},
+			)),
+		},
+		Hidden: false,
+	}
+	//nolint:lll
+	regexColor = regexp.MustCompile(`<((?:fg=(?P<fg>\w+);?)?(?:bg=(?P<bg>\w+);?)?(?:options=(?P<options>\w+);?)?)?>(?P<label>.*?)</>`)
+	regexTag   = regexp.MustCompile(`<.*?>`)
+)
+
+type List struct {
+	Application Application `json:"application"`
+	Commands    []Command   `json:"commands"`
+	Namespace   string      `json:"namespace,omitempty"`
+	Namespaces  []Namespace `json:"namespaces,omitempty"`
+}
+
+type Application struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Command struct {
+	Name        CommandName `json:"name"`
+	Usage       []string    `json:"usage"` // + aliases
+	Description CleanString `json:"description"`
+	Help        CleanString `json:"help"`
+	Definition  Definition  `json:"definition"`
+	Hidden      bool        `json:"hidden"`
+}
+
+type CommandName struct {
+	Namespace string
+	Command   string
+}
+
+func (n *CommandName) String() string {
+	if n.Namespace == "" {
+		return n.Command
+	}
+	return n.Namespace + ":" + n.Command
+}
+
+func (n *CommandName) ContainsNamespace() bool {
+	return n.Namespace != ""
+}
+
+func (n *CommandName) MarshalJSON() ([]byte, error) {
+	return json.Marshal(n.String())
+}
+
+func (n *CommandName) UnmarshalJSON(text []byte) error {
+	var command string
+	err := json.Unmarshal(text, &command)
+	if err != nil {
+		return err
+	}
+	names := strings.SplitN(command, ":", 2)
+	switch {
+	case len(names) == 1:
+		n.Command = names[0]
+	case len(names) > 1:
+		n.Namespace = names[0]
+		n.Command = names[1]
+	}
+	return nil
+}
+
+type CleanString string
+
+func (s CleanString) String() string {
+	return string(s)
+}
+
+func (s *CleanString) MarshalJSON() ([]byte, error) {
+	buff := new(bytes.Buffer)
+	encoder := json.NewEncoder(buff)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(s.String())
+	return buff.Bytes(), err
+}
+
+func (s *CleanString) UnmarshalJSON(text []byte) error {
+	var str string
+	err := json.Unmarshal(text, &str)
+	if err != nil {
+		return err
+	}
+
+	match := regexColor.FindStringSubmatch(str)
+	if len(match) != 0 {
+		res := make(map[string]string)
+		for i, name := range regexColor.SubexpNames() {
+			if i != 0 && name != "" {
+				res[name] = match[i]
+			}
+		}
+
+		atrs := make([]color.Attribute, 0, 2)
+		switch res["fg"] {
+		case "white":
+			atrs = append(atrs, color.FgWhite)
+		case "red":
+			atrs = append(atrs, color.FgRed)
+		case "yellow":
+			atrs = append(atrs, color.FgYellow)
+		}
+		switch res["bg"] {
+		case "white":
+			atrs = append(atrs, color.BgWhite)
+		case "red":
+			atrs = append(atrs, color.BgRed)
+		case "yellow":
+			atrs = append(atrs, color.BgYellow)
+		}
+		colorStr := color.New(atrs...).SprintFunc()
+
+		str = regexColor.ReplaceAllString(str, colorStr(res["label"]))
+	}
+
+	// Remove all remain tags like <comment></comment> and <info></info>
+	str = regexTag.ReplaceAllString(str, "")
+
+	*s = CleanString(str)
+	return nil
+}
+
+type Definition struct {
+	Arguments *orderedmap.OrderedMap[string, Argument] `json:"arguments"`
+	Options   *orderedmap.OrderedMap[string, Option]   `json:"options"`
+}
+
+type Argument struct {
+	Name        string      `json:"name"`
+	IsRequired  YesNo       `json:"is_required"`
+	IsArray     YesNo       `json:"is_array"`
+	Description CleanString `json:"description"`
+	Default     Any         `json:"default"`
+}
+
+type Option struct {
+	Name            string      `json:"name"`
+	Shortcut        string      `json:"shortcut"`
+	AcceptValue     YesNo       `json:"accept_value"`
+	IsValueRequired YesNo       `json:"is_value_required"`
+	IsMultiple      YesNo       `json:"is_multiple"`
+	Description     CleanString `json:"description"`
+	Default         Any         `json:"default"`
+	Hidden          bool        `json:"hidden"`
+}
+
+func (o *Option) GetName() string {
+	return strings.TrimPrefix(o.Name, "--")
+}
+
+type YesNo bool
+
+func (y YesNo) String() string {
+	if y {
+		return "yes"
+	}
+	return "no"
+}
+
+type Any struct {
+	any
+}
+
+func (a *Any) String() string {
+	if a.any == nil {
+		return "NULL"
+	}
+	switch t := a.any.(type) {
+	case bool:
+		return fmt.Sprintf("%t", a.any)
+	case float32, float64:
+		s := a.any.(float64) //nolint:errcheck
+		if s == math.Trunc(s) {
+			return fmt.Sprintf("%d", int64(s))
+		}
+		return fmt.Sprintf("%f", s)
+	case string:
+		s := a.any.(string) //nolint:errcheck
+		return fmt.Sprintf("'%s'", s)
+	case []any, []string, []int, []float64:
+		return "array ()"
+	default:
+		panic(fmt.Sprintf("options: unsupported type: %T", t))
+	}
+}
+
+func (a Any) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.any)
+}
+
+func (a *Any) UnmarshalJSON(text []byte) error {
+	return json.Unmarshal(text, &a.any)
+}
+
+type Namespace struct {
+	ID       string   `json:"id"`
+	Commands []string `json:"commands"` // the same as Command.Name
+}
+
+func (l *List) DescribesNamespace() bool {
+	return l.Namespace != ""
+}
+
+func (l *List) AddCommand(cmd *Command) {
+	for i := range l.Namespaces {
+		name := &l.Namespaces[i]
+		if name.ID == cmd.Name.Namespace {
+			name.Commands = append(name.Commands, cmd.Name.String())
+			sort.Strings(name.Commands)
+		}
+	}
+
+	l.Commands = append(l.Commands, *cmd)
+	sort.Slice(l.Commands, func(i, j int) bool {
+		switch {
+		case !l.Commands[i].Name.ContainsNamespace() && l.Commands[j].Name.ContainsNamespace():
+			return true
+		case l.Commands[i].Name.ContainsNamespace() && !l.Commands[j].Name.ContainsNamespace():
+			return false
+		default:
+			return l.Commands[i].Name.String() < l.Commands[j].Name.String()
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/platformsh/cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fatih/color v1.13.0
@@ -9,6 +9,7 @@ require (
 	github.com/platformsh/platformify v0.1.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
+	github.com/wk8/go-ordered-map/v2 v2.1.7
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )
 
@@ -17,6 +18,8 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -25,6 +28,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -152,6 +156,7 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -166,6 +171,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
@@ -225,6 +232,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/wk8/go-ordered-map/v2 v2.1.7 h1:aUZ1xBMdbvY8wnNt77qqo4nyT3y0pX4Usat48Vm+hik=
+github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTzI7c2bz7/G7ZN4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/md/builder.go
+++ b/internal/md/builder.go
@@ -1,0 +1,76 @@
+package md
+
+import (
+	"strings"
+)
+
+type Builder struct {
+	buff *strings.Builder
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		buff: new(strings.Builder),
+	}
+}
+
+func (b *Builder) String() string {
+	return b.buff.String()
+}
+
+func (b *Builder) H1(s string) *Builder {
+	return b.heading(L1, s)
+}
+
+func (b *Builder) H2(s string) *Builder {
+	return b.heading(L2, s)
+}
+
+func (b *Builder) H3(s string) *Builder {
+	return b.heading(L3, s)
+}
+
+func (b *Builder) H4(s string) *Builder {
+	return b.heading(L4, s)
+}
+
+func (b *Builder) H5(s string) *Builder {
+	return b.heading(L5, s)
+}
+
+func (b *Builder) H6(s string) *Builder {
+	return b.heading(L6, s)
+}
+
+func (b *Builder) Paragraph(s string) *Builder {
+	return b.write(s)
+}
+
+func (b *Builder) Ln() *Builder {
+	return b.ln()
+}
+
+func (b *Builder) CodeBlock(s string) *Builder {
+	return b.write(CodeBlock(s))
+}
+
+func (b *Builder) ListItem(s string) *Builder {
+	return b.write(UnorderedListItem(s))
+}
+
+func (b *Builder) heading(level HeadingLevel, s string) *Builder {
+	return b.write(Heading(level, s)).ln()
+}
+
+func (b *Builder) write(s string) *Builder {
+	if s == "" {
+		return b
+	}
+	b.buff.WriteString(s)
+	return b.ln()
+}
+
+func (b *Builder) ln() *Builder {
+	b.buff.WriteString("\n")
+	return b
+}

--- a/internal/md/syntax.go
+++ b/internal/md/syntax.go
@@ -1,0 +1,73 @@
+package md
+
+import (
+	"fmt"
+	"strings"
+)
+
+type HeadingLevel int
+
+const (
+	L1 HeadingLevel = iota + 1
+	L2
+	L3
+	L4
+	L5
+	L6
+)
+
+func Heading(level HeadingLevel, s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.Repeat("#", int(level)) + " " + s
+}
+
+func Bold(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "**" + s + "**"
+}
+
+func Italic(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "*" + s + "*"
+}
+
+func UnorderedListItem(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "* " + s
+}
+
+func Code(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "`" + s + "`"
+}
+
+func CodeBlock(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "```\n" + s + "\n```"
+}
+
+func Link(text, url string) string {
+	if text == "" || url == "" {
+		return ""
+	}
+	return fmt.Sprintf("[%s](%s)", text, url)
+}
+
+func Anchor(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "#" + strings.ReplaceAll(s, ":", "")
+}


### PR DESCRIPTION
We need to override the platform list command on the Go side, to be able to include the new command (platform project:init) in the list of commands.

This should include both platform list and platform list project.

Technical details

Proxy to the legacy list command using --format=json Parse the JSON response
Add the extra commands, if needed
Return the enhanced result in the correct format (the one the user asked for)