### PR TITLE
Fix shortcut for project:init command.

### DIFF
--- a/commands/platformify.go
+++ b/commands/platformify.go
@@ -12,7 +12,7 @@ func init() {
 var PlatformifyCmd = &cobra.Command{
 	Use:           "project:init",
 	Short:         "Initialize the needed YAML files for your Platform.sh project",
-	Aliases:       []string{"ify"},
+	Aliases:       []string{"p:init", "ify"},
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          commands.PlatformifyCmd.RunE,


### PR DESCRIPTION
Attempting to use shortcut for the "init" command throws an error.

Fixes: https://github.com/platformsh/platformify/issues/85