### PR TITLE
Remove dependency on oniguruma and openssl on macOS.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,6 +103,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    rlcp: true
 
 brews:
   - name: platformsh-cli
@@ -125,8 +126,6 @@ brews:
     dependencies:
       - name: git
         type: optional
-      - name: oniguruma
-      - name: openssl@1.1
 
     install: |
       bin.install "platform"
@@ -135,20 +134,20 @@ brews:
     test: |
       system "#{bin}/platform --version"
 
-scoop:
-  bucket:
-    owner: platformsh
-    name: homebrew-tap
-    token: "{{ .Env.GITHUB_TOKEN }}"
+scoops:
+  - bucket:
+      owner: platformsh
+      name: homebrew-tap
+      token: "{{ .Env.GITHUB_TOKEN }}"
 
-  folder: Scoops
-  commit_author:
-    name: Antonis Kalipetis
-    email: antonis.kalipetis@platform.sh
+    folder: Scoops
+    commit_author:
+      name: Antonis Kalipetis
+      email: antonis.kalipetis@platform.sh
 
-  homepage: https://docs.platform.sh/administration/cli.html
-  description: Platform.sh CLI
-  license: MIT
+    homepage: https://docs.platform.sh/administration/cli.html
+    description: Platform.sh CLI
+    license: MIT
 
 nfpms:
   - homepage: https://docs.platform.sh/administration/cli.html

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 PHP_VERSION = 8.0.28
 PSH_VERSION = 4.6.0
+# The OpenSSL version must be compatible with the PHP version.
+# See: https://www.php.net/manual/en/openssl.requirements.php
+OPENSSL_VERSION = 1.1.1t
 GOOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ifeq ($(GOOS), darwin)
 	GORELEASER_ID=platform-macos
@@ -16,12 +19,12 @@ endif
 PHP_BINARY_PATH := internal/legacy/archives/php_$(GOOS)_$(GOARCH)
 
 internal/legacy/archives/platform.phar:
-	wget https://github.com/platformsh/legacy-cli/releases/download/v$(PSH_VERSION)/platform.phar -O internal/legacy/archives/platform.phar
+	curl -L https://github.com/platformsh/legacy-cli/releases/download/v$(PSH_VERSION)/platform.phar -o internal/legacy/archives/platform.phar
 
 internal/legacy/archives/php_windows_amd64: internal/legacy/archives/php_windows.zip internal/legacy/archives/cacert.pem
 
 internal/legacy/archives/php_darwin_$(GOARCH):
-	bash build-php-brew.sh $(PHP_VERSION) $(GOOS)
+	bash build-php-brew.sh $(GOOS) $(PHP_VERSION) $(OPENSSL_VERSION)
 	mv -f $(GOOS)/php-$(PHP_VERSION)/sapi/cli/php $(PHP_BINARY_PATH)
 	rm -rf $(GOOS)
 
@@ -48,16 +51,16 @@ internal/legacy/archives/cacert.pem:
 php: $(PHP_BINARY_PATH)
 
 single: internal/legacy/archives/platform.phar php
-	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser build --single-target --id=$(GORELEASER_ID) --snapshot --rm-dist
+	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser build --single-target --id=$(GORELEASER_ID) --snapshot --clean
 
 snapshot: internal/legacy/archives/platform.phar php
-	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser build --snapshot --rm-dist
+	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser build --snapshot --clean
 
 clean-phar:
 	rm -f internal/legacy/archives/platform.phar
 
 release: clean-phar internal/legacy/archives/platform.phar php
-	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser release --rm-dist --auto-snapshot
+	PHP_VERSION=$(PHP_VERSION) PSH_VERSION=$(PSH_VERSION) goreleaser release --clean --auto-snapshot
 
 .PHONY: test
 test: ## Run unit tests

--- a/build-php-brew.sh
+++ b/build-php-brew.sh
@@ -3,6 +3,9 @@ set -ex
 DIR=$1
 PHP_VERSION=$2
 OPENSSL_VERSION=$3
+
+brew install bison pkg-config coreutils autoconf
+
 SSL_DIR_PATH=$(pwd)/"$DIR"/ssl
 mkdir -p "$SSL_DIR_PATH"
 

--- a/build-php-brew.sh
+++ b/build-php-brew.sh
@@ -1,13 +1,21 @@
 set -ex
 
-brew install bison openssl@1.1 pkg-config coreutils autoconf
-BREW_PREFIX=$(brew --prefix)
-export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_PREFIX/opt/openssl@1.1/lib/pkgconfig"
+DIR=$1
+PHP_VERSION=$2
+OPENSSL_VERSION=$3
+SSL_DIR_PATH=$(pwd)/"$DIR"/ssl
+mkdir -p "$SSL_DIR_PATH"
 
-DIR=$2
-mkdir -p $DIR
-curl -fSsl https://www.php.net/distributions/php-$1.tar.gz | tar  xzf - -C $DIR
-cd $DIR/php-$1
+curl -fSsl https://www.openssl.org/source/openssl-"$OPENSSL_VERSION".tar.gz | tar  xzf - -C "$DIR"
+cd "$DIR"/openssl-"$OPENSSL_VERSION"
+
+./config no-shared --prefix="$SSL_DIR_PATH" --openssldir="$SSL_DIR_PATH"
+make
+make install
+
+cd ../..
+curl -fSsl https://www.php.net/distributions/php-"$PHP_VERSION".tar.gz | tar  xzf - -C "$DIR"
+cd "$DIR"/php-"$PHP_VERSION"
 
 rm -f sapi/cli/php
 
@@ -25,6 +33,8 @@ rm -f sapi/cli/php
   --with-openssl \
   --with-pear=no \
   --without-pcre-jit \
-  --disable-all
+  --disable-all \
+OPENSSL_CFLAGS="-I$SSL_DIR_PATH/include" \
+OPENSSL_LIBS="-L$SSL_DIR_PATH/lib -lssl -lcrypto"
 
-make -j$(nproc) cli
+make -j"$(nproc)" cli


### PR DESCRIPTION
Download source code and build a static library.
Directly include the static library into PHP binary file.
The size of the PHP binary file became larger (8.4Mb against 5.7Mb).
Compiling the OpenSSL/LibreSSL libraries takes ≈ 9-10min (previous time ≈ 4-5min).

Closes: https://github.com/platformsh/cli/issues/26