### PR TITLE
Bump legacy CLI version to 4.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PHP_VERSION = 8.0.28
-PSH_VERSION = 4.7.0
+PSH_VERSION = 4.7.1
 # The OpenSSL version must be compatible with the PHP version.
 # See: https://www.php.net/manual/en/openssl.requirements.php
 OPENSSL_VERSION = 1.1.1t


### PR DESCRIPTION
https://github.com/platformsh/legacy-cli/releases/tag/v4.7.1

Somewhat urgent due to:

> * Restore the check to prevent deleting parent environments.  
>   The check had been imprudently removed in v4.7.0.  
>   This adds an option --allow-delete-parent as a way to skip the check.