### PR TITLE
Release packages to Cloudsmith

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ifeq ($(GOARCH), aarch64)
 endif
 
 PHP_BINARY_PATH := internal/legacy/archives/php_$(GOOS)_$(GOARCH)
+VERSION := $(shell git describe --always)
 
 # Tooling versions
 GORELEASER_VERSION=v1.20
@@ -80,7 +81,8 @@ clean-phar:
 	rm -f internal/legacy/archives/platform.phar
 
 release: goreleaser clean-phar internal/legacy/archives/platform.phar php copy-config-file
-	PHP_VERSION=$(PHP_VERSION) LEGACY_CLI_VERSION=$(LEGACY_CLI_VERSION) goreleaser release --clean --auto-snapshot --config="$(GORELEASER_CONFIG_FILE)"
+	PHP_VERSION=$(PHP_VERSION) LEGACY_CLI_VERSION=$(LEGACY_CLI_VERSION) goreleaser release --clean --config="$(GORELEASER_CONFIG_FILE)"
+	VERSION=$(VERSION) bash cloudsmith.sh
 
 .PHONY: test
 test: ## Run unit tests

--- a/README.md
+++ b/README.md
@@ -60,6 +60,72 @@ The installer is configurable using the following environment variables:
     curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | INSTALL_METHOD=raw INSTALL_DIR=$HOME/.local/bin bash
 </details>
 
+### Alpine
+
+```console
+sudo apk add --no-cache bash
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/platformsh/cli/setup.alpine.sh' \
+  | sudo -E bash
+```
+
+<details>
+    <summary>Manual setup</summary>
+
+    apk add --no-cache curl
+    curl -1sLf 'https://dl.cloudsmith.io/public/platformsh/cli/rsa.4F1C2AC5106DA770.key' > /etc/apk/keys/cli@platformsh-4F1C2AC5106DA770.rsa.pub
+    curl -1sLf "https://dl.cloudsmith.io/public/platformsh/cli/config.alpine.txt" >> /etc/apk/repositories
+    apk update
+
+</details>
+
+```console
+# Install the CLI
+apk add platformsh-cli
+```
+
+### Ubuntu/Debian
+
+```console
+apt-get update
+apt-get install -y apt-transport-https curl
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/platformsh/cli/setup.deb.sh' \
+  | sudo -E bash
+```
+
+<details>
+    <summary>Manual setup</summary>
+
+    apt-get update
+
+    # Only needed for Debian
+    apt-get install -y debian-keyring debian-archive-keyring
+
+    apt-get install -y apt-transport-https curl gnupg
+    curl -1sLf 'https://dl.cloudsmith.io/public/platformsh/cli/gpg.6ED8A90E60ABD941.key' |  gpg --dearmor >> /usr/share/keyrings/platformsh-cli-archive-keyring.gpg
+    # If you use an Ubuntu derivative distro, such as Linux Mint, you may need to use UBUNTU_CODENAME instead of VERSION_CODENAME below.
+    curl -1sLf "https://dl.cloudsmith.io/public/platformsh/cli/config.deb.txt?distro=$(. /etc/os-release && echo "$ID")&codename=$(. /etc/os-release && echo "$VERSION_CODENAME")" > /etc/apt/sources.list.d/platformsh-cli.list
+    apt-get update
+
+</details>
+
+```console
+# Install the CLI
+apt-get install -y platformsh-cli
+```
+
+### CentOS/RHEL/Fedora
+
+```console
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/platformsh/cli/setup.rpm.sh' \
+  | sudo -E bash
+
+# Install the CLI
+yum install -y platformsh-cli
+```
+
 ### Manual installation
 
 For manual installation, you can also [download the latest binaries](https://github.com/platformsh/cli/releases/latest).
@@ -84,6 +150,24 @@ scoop update platform
 
 ```console
 curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
+```
+
+### Alpine
+
+```console
+apk add -l platformsh-cli
+```
+
+### Ubuntu/Debian
+
+```console
+apt-get upgrade platformsh-cli
+```
+
+### CentOS/RHEL/Fedora
+
+```console
+yum upgrade -y platformsh-cli
 ```
 
 ## Under the hood

--- a/cloudsmith.sh
+++ b/cloudsmith.sh
@@ -1,0 +1,11 @@
+cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_arm64.deb
+cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_amd64.deb
+
+cloudsmith push alpine platformsh/cli/alpine/any-version dist/platformsh-cli_${VERSION}_linux_amd64.apk
+cloudsmith push alpine platformsh/cli/alpine/any-version dist/platformsh-cli_${VERSION}_linux_arm64.apk
+
+cloudsmith push rpm platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_amd64.rpm
+cloudsmith push rpm platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_arm64.rpm
+
+cloudsmith push raw platformsh/cli dist/platform_${VERSION}_linux_amd64.tar.gz --version ${VERSION}
+cloudsmith push raw platformsh/cli dist/platform_${VERSION}_linux_arm64.tar.gz --version ${VERSION}

--- a/commands/root.go
+++ b/commands/root.go
@@ -168,15 +168,19 @@ func printUpdateMessage(newRelease *internal.ReleaseInfo, cnf *config.Config) {
 		color.CyanString(newRelease.Version),
 	)
 
-	if cnf.Wrapper.HomebrewTap != "" {
-		executable, err := os.Executable()
-		if err == nil && isUnderHomebrew(executable) {
-			fmt.Fprintf(
-				color.Error,
-				"To upgrade, run: brew update && brew upgrade %s\n",
-				color.YellowString(cnf.Wrapper.HomebrewTap),
-			)
-		}
+	executable, err := os.Executable()
+	if err == nil && cnf.Wrapper.HomebrewTap != "" && isUnderHomebrew(executable) {
+		fmt.Fprintf(
+			color.Error,
+			"To upgrade, run: brew update && brew upgrade %s\n",
+			color.YellowString(cnf.Wrapper.HomebrewTap),
+		)
+	} else if cnf.Wrapper.GitHubRepo != "" {
+		fmt.Fprintf(
+			color.Error,
+			"To upgrade, follow the instructions at: https://github.com/%s#upgrade\n",
+			cnf.Wrapper.GitHubRepo,
+		)
 	}
 
 	fmt.Fprintf(color.Error, "%s\n\n", color.YellowString(newRelease.URL))

--- a/installer.sh
+++ b/installer.sh
@@ -183,7 +183,7 @@ function check_gzip() {
 
 function check_version() {
     if [ -z "${VERSION}" ]; then
-        version=$(github_curl https://api.github.com/repos/platformsh/cli/releases/latest | sed -n 's/.*"tag_name":.\?"\([^"]*\)".*/\1/p')
+        version=$(curl -I https://github.com/platformsh/cli/releases/latest 2>/dev/null | awk -F/ -v RS='\r\n' '/platformsh.cli.releases.tag/ {printf "%s", $NF}')
         output "  [*] No version specified, using latest ($version)" "success"
     else
         output "  [*] Version ${VERSION} specified" "success"


### PR DESCRIPTION
* Upload packages to Cloudsmith on release
* Update README with instructions on how to install the Linux packages for each supported distribution
* Update the installer to install the Linux packages when run interactively and outside of CI systems

Fix #63 