### PR TITLE
Bump Platformify to v0.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/gofrs/flock v0.8.1
 	github.com/mattn/go-isatty v0.0.16
-	github.com/platformsh/platformify v0.2.2
+	github.com/platformsh/platformify v0.2.3
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/platformsh/platformify v0.2.1 h1:pSxJUGZbtd76HFRNqX7Hy+kyM+wH21E2EWHh
 github.com/platformsh/platformify v0.2.1/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/platformsh/platformify v0.2.2 h1:pGWI9JqgzaSTyFP+lacrHfOpZQ6yqilx3abVsbmZ7uc=
 github.com/platformsh/platformify v0.2.2/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
+github.com/platformsh/platformify v0.2.3 h1:+0cVerZdBx58U4Ju4AC9j7ynT19/kZMUzkq3yMrFgjM=
+github.com/platformsh/platformify v0.2.3/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Release notes: https://github.com/platformsh/platformify/releases/tag/v0.2.3
