### PR TITLE
Fix verbose, no interaction and CLI version display

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -116,6 +116,8 @@ func newRootCommand(cnf *config.Config, assets *vendorization.VendorAssets) *cob
 		fmt.Sprintf("Uses a local .phar file for the Legacy %s", cnf.Application.Name),
 	)
 	cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
+	cmd.PersistentFlags().Bool("no-interaction", false, "Enable non-interactive mode")
+	cmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 
 	projectInitCmd := commands.NewPlatformifyCmd(assets)
 	projectInitCmd.SetHelpFunc(func(_ *cobra.Command, args []string) {

--- a/commands/version.go
+++ b/commands/version.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -25,23 +24,18 @@ func newVersionCommand(cnf *config.Config) *cobra.Command {
 		Short:              "Print the version number of the " + cnf.Application.Name,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Run: func(cmd *cobra.Command, args []string) {
-			if strings.Split(version, "-")[0] != strings.Split(legacy.LegacyCLIVersion, "-")[0] {
-				fmt.Fprintf(
-					color.Output,
-					"%s %s (Wrapped legacy CLI %s)\n",
-					cnf.Application.Name,
-					color.CyanString(version),
-					color.CyanString(legacy.LegacyCLIVersion),
-				)
-			} else {
-				fmt.Fprintf(color.Output, "%s %s (Wrapped)\n", cnf.Application.Name, color.CyanString(version))
-			}
+			fmt.Fprintf(color.Output, "%s %s\n", cnf.Application.Name, color.CyanString(version))
 
-			if viper.GetBool("debug") {
+			if viper.GetBool("verbose") {
 				fmt.Fprintf(
 					color.Output,
 					"Embedded PHP version %s\n",
 					color.CyanString(legacy.PHPVersion),
+				)
+				fmt.Fprintf(
+					color.Output,
+					"Embedded Legacy CLI version %s\n",
+					color.CyanString(legacy.LegacyCLIVersion),
 				)
 				fmt.Fprintf(
 					color.Output,


### PR DESCRIPTION
* Add `--no-interaction` and `--verbose` as persistent flags - fix #135 
* Stop displaying the Legacy CLI version