### PR TITLE
Bump Platformify to v0.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/gofrs/flock v0.8.1
 	github.com/mattn/go-isatty v0.0.16
-	github.com/platformsh/platformify v0.2.3
+	github.com/platformsh/platformify v0.2.4
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -207,12 +207,6 @@ github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvI
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/platformsh/platformify v0.2.1 h1:pSxJUGZbtd76HFRNqX7Hy+kyM+wH21E2EWHhnQYpPQw=
-github.com/platformsh/platformify v0.2.1/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
-github.com/platformsh/platformify v0.2.2 h1:pGWI9JqgzaSTyFP+lacrHfOpZQ6yqilx3abVsbmZ7uc=
-github.com/platformsh/platformify v0.2.2/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
-github.com/platformsh/platformify v0.2.3 h1:+0cVerZdBx58U4Ju4AC9j7ynT19/kZMUzkq3yMrFgjM=
-github.com/platformsh/platformify v0.2.3/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/platformsh/platformify v0.2.4 h1:YUFBie2Es4vDcOZCuJF1C/xM8c6VXaSpGx+r/DZLmaQ=
 github.com/platformsh/platformify v0.2.4/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/platformsh/platformify v0.2.2 h1:pGWI9JqgzaSTyFP+lacrHfOpZQ6yqilx3abV
 github.com/platformsh/platformify v0.2.2/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/platformsh/platformify v0.2.3 h1:+0cVerZdBx58U4Ju4AC9j7ynT19/kZMUzkq3yMrFgjM=
 github.com/platformsh/platformify v0.2.3/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
+github.com/platformsh/platformify v0.2.4 h1:YUFBie2Es4vDcOZCuJF1C/xM8c6VXaSpGx+r/DZLmaQ=
+github.com/platformsh/platformify v0.2.4/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Release notes:
* Fix #167: Missing locations root leads to 500 once the app is deployed by @lolautruche in https://github.com/platformsh/platformify/pull/168
* Bump Node default version to 20 by @lolautruche in https://github.com/platformsh/platformify/pull/172
* Name is about application, not project by @lolautruche in https://github.com/platformsh/platformify/pull/173
* Skip empty files when generating by @akalipetis in https://github.com/platformsh/platformify/pull/179
* Fix Laravel database and n handling by @akalipetis in https://github.com/platformsh/platformify/pull/180
* Add more Strapi-specific environment variables by @akalipetis in https://github.com/platformsh/platformify/pull/181