### PR TITLE
Bump Platformify to v0.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/gofrs/flock v0.8.1
 	github.com/mattn/go-isatty v0.0.16
-	github.com/platformsh/platformify v0.2.4
+	github.com/platformsh/platformify v0.2.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvI
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/platformsh/platformify v0.2.4 h1:YUFBie2Es4vDcOZCuJF1C/xM8c6VXaSpGx+r/DZLmaQ=
-github.com/platformsh/platformify v0.2.4/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
+github.com/platformsh/platformify v0.2.5 h1:JaI+bSI7WdV09V2IUSnyo3JQrzm6R/iQ94RMsrOM/Bk=
+github.com/platformsh/platformify v0.2.5/go.mod h1:OTcTo+D6DJXQswy7D2yfzgx4v3wUai3fU5BGAXr2FjI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
## Release notes
* Include more recent supported service versions by @chadwcarlson in https://github.com/platformsh/platformify/pull/183
* Replace `local` mount source by `storage` for Upsun by @lolautruche in https://github.com/platformsh/platformify/pull/177
* Change service names to have dashes only by @akalipetis in https://github.com/platformsh/platformify/pull/185
* Remove sharp as a Node.js dependency by @akalipetis in https://github.com/platformsh/platformify/pull/188
* Next.js: Fallback to next build if no build script is found by @akalipetis in https://github.com/platformsh/platformify/pull/187
* Add APP_KEYS environment variable to .environment by @akalipetis in https://github.com/platformsh/platformify/pull/189

**Full Changelog**: https://github.com/platformsh/platformify/compare/v0.2.4...v0.2.5
