### PR TITLE
Enable PHP zip extension for Windows build

### DIFF
--- a/ext/extensions.txt
+++ b/ext/extensions.txt
@@ -41,4 +41,4 @@ posix
 ^xmlreader
 ^xmlwriter
 zlib
-^zip
+zip


### PR DESCRIPTION
It's somewhat needed by the legacy CLI for the credential helper download: https://github.com/platformsh/legacy-cli/blob/40c24497c29cb937151b1cf7ceff092bdc5aee16/src/CredentialHelper/Manager.php#L219-L223