### PR TITLE
Add a --quiet (-q) flag to silence stderr

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -29,13 +29,14 @@ func newCompletionCommand(cnf *config.Config) *cobra.Command {
 			}
 			var b bytes.Buffer
 			c := &legacy.CLIWrapper{
-				Config:         cnf,
-				Version:        version,
-				CustomPharPath: viper.GetString("phar-path"),
-				Debug:          viper.GetBool("debug"),
-				Stdout:         &b,
-				Stderr:         cmd.ErrOrStderr(),
-				Stdin:          cmd.InOrStdin(),
+				Config:             cnf,
+				Version:            version,
+				CustomPharPath:     viper.GetString("phar-path"),
+				Debug:              viper.GetBool("debug"),
+				DisableInteraction: viper.GetBool("no-interaction"),
+				Stdout:             &b,
+				Stderr:             cmd.ErrOrStderr(),
+				Stdin:              cmd.InOrStdin(),
 			}
 
 			if err := c.Init(); err != nil {

--- a/commands/list.go
+++ b/commands/list.go
@@ -24,13 +24,14 @@ func newListCommand(cnf *config.Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			var b bytes.Buffer
 			c := &legacy.CLIWrapper{
-				Config:         cnf,
-				Version:        version,
-				CustomPharPath: viper.GetString("phar-path"),
-				Debug:          viper.GetBool("debug"),
-				Stdout:         &b,
-				Stderr:         cmd.ErrOrStderr(),
-				Stdin:          cmd.InOrStdin(),
+				Config:             cnf,
+				Version:            version,
+				CustomPharPath:     viper.GetString("phar-path"),
+				Debug:              viper.GetBool("debug"),
+				DisableInteraction: viper.GetBool("no-interaction"),
+				Stdout:             &b,
+				Stderr:             cmd.ErrOrStderr(),
+				Stdin:              cmd.InOrStdin(),
 			}
 			if err := c.Init(); err != nil {
 				debugLog("%s\n", color.RedString(err.Error()))

--- a/internal/legacy/legacy.go
+++ b/internal/legacy/legacy.go
@@ -69,13 +69,14 @@ func fileChanged(filename string, content []byte) (bool, error) {
 
 // CLIWrapper wraps the legacy CLI
 type CLIWrapper struct {
-	Stdout         io.Writer
-	Stderr         io.Writer
-	Stdin          io.Reader
-	Config         *config.Config
-	Version        string
-	CustomPharPath string
-	Debug          bool
+	Stdout             io.Writer
+	Stderr             io.Writer
+	Stdin              io.Reader
+	Config             *config.Config
+	Version            string
+	CustomPharPath     string
+	Debug              bool
+	DisableInteraction bool
 }
 
 func (c *CLIWrapper) cacheDir() string {
@@ -169,6 +170,9 @@ func (c *CLIWrapper) Exec(ctx context.Context, args ...string) error {
 	)
 	if c.Debug {
 		cmd.Env = append(cmd.Env, envPrefix+"CLI_DEBUG=1")
+	}
+	if c.DisableInteraction {
+		cmd.Env = append(cmd.Env, envPrefix+"NO_INTERACTION=1")
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf(
 		"%sUSER_AGENT={APP_NAME_DASH}/%s ({UNAME_S}; {UNAME_R}; PHP %s; WRAPPER %s)",


### PR DESCRIPTION
I think we'd want #208 first so that the legacy CLI behaves in the same way (incorporating https://github.com/platformsh/legacy-cli/pull/1483)