### PR TITLE
Test legacy cli commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ platform: internal/legacy/archives/platform.phar php
 
 .PHONY: integration-test
 integration-test: platform
-	TEST_CLI_PATH="$(PWD)/platform" go test -failfast -mod=readonly -v ./tests/integration/...
+	TEST_CLI_PATH="$(PWD)/platform" go test ./tests/integration/...
 
 golangci-lint:
 	command -v golangci-lint >/dev/null || go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/tests/integration/environment_list_test.go
+++ b/tests/integration/environment_list_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platformsh/cli/tests/integration/mocks"
+)
+
+func TestEnvironmentList(t *testing.T) {
+	authServer := mocks.APITokenServer(t)
+	defer authServer.Close()
+
+	apiServer := environmentListServer(t)
+	defer apiServer.Close()
+
+	// The legacy CLI identifier expects project IDs to be alphanumeric.
+	// See: https://github.com/platformsh/legacy-cli/blob/main/src/Service/Identifier.php#L75
+	mockProjectID := "abcdefg123456"
+
+	run := func(args ...string) string {
+		cmd := command(t, args...)
+		cmd.Env = append(
+			cmd.Env,
+			EnvPrefix+"API_BASE_URL="+apiServer.URL,
+			EnvPrefix+"API_AUTH_URL="+authServer.URL,
+			EnvPrefix+"TOKEN="+mocks.ValidAPITokens[0],
+		)
+		if testing.Verbose() {
+			cmd.Stderr = os.Stderr
+		}
+
+		b, err := cmd.Output()
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	assert.Equal(t, strings.TrimLeft(`
++-----------+---------+----------+-------------+
+| ID        | Title   | Status   | Type        |
++-----------+---------+----------+-------------+
+| main      | Main    | Active   | production  |
+|   staging | Staging | Active   | staging     |
+|     dev   | Dev     | Active   | development |
+|       fix | Fix     | Inactive | development |
++-----------+---------+----------+-------------+
+`, "\n"), run("environment:list", "-v", "-p", mockProjectID))
+
+	assert.Equal(t, strings.TrimLeft(`
+ID	Title	Status	Type
+main	Main	Active	production
+staging	Staging	Active	staging
+dev	Dev	Active	development
+fix	Fix	Inactive	development
+`, "\n"), run("environment:list", "-v", "-p", mockProjectID, "--format", "plain"))
+
+	assert.Equal(t, strings.TrimLeft(`
+ID	Title	Status	Type
+main	Main	Active	production
+staging	Staging	Active	staging
+dev	Dev	Active	development
+`, "\n"), run("environment:list", "-v", "-p", mockProjectID, "--format", "plain", "--no-inactive"))
+
+	assert.Equal(t, "fix\n",
+		run("environment:list", "-v", "-p", mockProjectID, "--pipe", "--status=inactive"))
+}
+
+func environmentListServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if testing.Verbose() {
+			t.Log(req)
+		}
+		switch {
+		case req.Method == http.MethodGet &&
+			regexp.MustCompile(`^/projects/[a-z0-9-]+$`).MatchString(req.URL.Path):
+			p := project{
+				ID:    path.Base(req.URL.Path),
+				Links: makeHALLinks("self="+req.URL.Path, "environments="+req.URL.Path+"/environments"),
+			}
+			_ = json.NewEncoder(w).Encode(p)
+			return
+		case req.Method == http.MethodGet &&
+			regexp.MustCompile(`^/projects/[a-z0-9-]+/environments$`).MatchString(req.URL.Path):
+			makeEnv := func(name, envType, status string, parent any) environment {
+				return environment{
+					ID:          name,
+					Name:        name,
+					MachineName: name + "-xyz",
+					Title:       strings.ToTitle(name[:1]) + name[1:],
+					Parent:      parent,
+					Type:        envType,
+					Status:      status,
+					Links:       makeHALLinks("self=" + req.URL.Path + "/" + url.PathEscape(name)),
+				}
+			}
+			_ = json.NewEncoder(w).Encode([]environment{
+				makeEnv("main", "production", "active", nil),
+				makeEnv("staging", "staging", "active", "main"),
+				makeEnv("dev", "development", "active", "staging"),
+				makeEnv("fix", "development", "inactive", "dev"),
+			})
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -20,10 +20,10 @@ func getCommandName(t *testing.T) string {
 	if candidate == "" {
 		t.Skip("enable by setting TEST_CLI_PATH (or use `make integration-test`)")
 	}
-	versionCmd := exec.Command(candidate, "version")
+	versionCmd := exec.Command(candidate, "--version")
 	versionCmd.Env = testEnv()
 	output, err := versionCmd.Output()
-	require.NoError(t, err, "the 'version' command must succeed under the CLI at: %s", candidate)
+	require.NoError(t, err, "running '--version' must succeed under the CLI at: %s", candidate)
 	require.Contains(t, string(output), "Platform Test CLI ")
 	if testing.Verbose() {
 		log.Printf("Validated CLI command %s", candidate)

--- a/tests/integration/mocks/token_server.go
+++ b/tests/integration/mocks/token_server.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"net/http"
 	"net/http/httptest"
 )
 
-var APITokens = map[string]string{
-	"api-token-1": "access-token1",
-}
+var ValidAPITokens = []string{"api-token-1"}
+var accessTokens = []string{"access-token-1"}
 
 // APITokenServer creates a new mock OAuth 2.0 API token server.
 // The caller must call Close() on the server when finished.
@@ -31,13 +32,13 @@ func APITokenServer(t *testing.T) *httptest.Server {
 				return
 			}
 			apiToken := req.Form.Get("api_token")
-			if accessToken, ok := APITokens[apiToken]; ok {
+			if slices.Contains(ValidAPITokens, apiToken) {
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(struct {
 					AccessToken string `json:"access_token"`
 					ExpiresIn   int    `json:"expires_in"`
 					Type        string `json:"token_type"`
-				}{AccessToken: accessToken, ExpiresIn: 60, Type: "bearer"})
+				}{AccessToken: accessTokens[0], ExpiresIn: 60, Type: "bearer"})
 				return
 			}
 			w.WriteHeader(http.StatusBadRequest)

--- a/tests/integration/mocks/token_server.go
+++ b/tests/integration/mocks/token_server.go
@@ -1,0 +1,50 @@
+package mocks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"net/http"
+	"net/http/httptest"
+)
+
+var APITokens = map[string]string{
+	"api-token-1": "access-token1",
+}
+
+// APITokenServer creates a new mock OAuth 2.0 API token server.
+// The caller must call Close() on the server when finished.
+func APITokenServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if testing.Verbose() {
+			t.Log(req)
+		}
+		if req.Method == http.MethodPost && req.URL.Path == "/oauth2/token" {
+			if err := req.ParseForm(); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+				return
+			}
+			if gt := req.Form.Get("grant_type"); gt != "api_token" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid grant type: " + gt})
+				return
+			}
+			apiToken := req.Form.Get("api_token")
+			if accessToken, ok := APITokens[apiToken]; ok {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(struct {
+					AccessToken string `json:"access_token"`
+					ExpiresIn   int    `json:"expires_in"`
+					Type        string `json:"token_type"`
+				}{AccessToken: accessToken, ExpiresIn: 60, Type: "bearer"})
+				return
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid API token"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+}

--- a/tests/integration/model.go
+++ b/tests/integration/model.go
@@ -61,5 +61,6 @@ type org struct {
 	ID    string   `json:"id"`
 	Name  string   `json:"name"`
 	Label string   `json:"label"`
+	Owner string   `json:"owner_id"`
 	Links halLinks `json:"_links"`
 }

--- a/tests/integration/model.go
+++ b/tests/integration/model.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"strings"
+	"time"
+)
+
+type halLink struct {
+	HREF string `json:"href"`
+}
+
+type halLinks map[string]halLink
+
+// makeHALLinks helps make a list of HAL links out of arguments in the format name=path.
+func makeHALLinks(nameAndPath ...string) halLinks {
+	links := make(halLinks, len(nameAndPath))
+	for _, p := range nameAndPath {
+		parts := strings.SplitN(p, "=", 2)
+		links[parts[0]] = halLink{parts[1]}
+	}
+	return links
+}
+
+// TODO unify these models with the 'api' package, and/or use OpenAPI or similar to generate them
+type subscription struct {
+	ID            string   `json:"id"`
+	Links         halLinks `json:"_links"`
+	ProjectID     string   `json:"project_id"`
+	ProjectRegion string   `json:"project_region"`
+	ProjectTitle  string   `json:"project_title"`
+	Status        string   `json:"status"`
+	ProjectUI     string   `json:"project_ui"`
+
+	eventualProjectID string
+}
+
+type projectRepository struct {
+	URL string `json:"url"`
+}
+
+type project struct {
+	ID         string            `json:"id"`
+	Repository projectRepository `json:"repository"`
+	Links      halLinks          `json:"_links"`
+}
+
+type environment struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	MachineName string    `json:"machine_name"`
+	Title       string    `json:"title"`
+	Type        string    `json:"type"`
+	Status      string    `json:"status"`
+	Parent      any       `json:"parent"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Links       halLinks  `json:"_links"`
+}
+
+type org struct {
+	ID    string   `json:"id"`
+	Name  string   `json:"name"`
+	Label string   `json:"label"`
+	Links halLinks `json:"_links"`
+}

--- a/tests/integration/org_list_test.go
+++ b/tests/integration/org_list_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platformsh/cli/tests/integration/mocks"
+)
+
+func TestOrgList(t *testing.T) {
+	authServer := mocks.APITokenServer(t)
+	defer authServer.Close()
+
+	apiServer := orgListServer(t)
+	defer apiServer.Close()
+
+	run := func(args ...string) string {
+		cmd := command(t, args...)
+		cmd.Env = append(
+			cmd.Env,
+			EnvPrefix+"API_BASE_URL="+apiServer.URL,
+			EnvPrefix+"API_AUTH_URL="+authServer.URL,
+			EnvPrefix+"TOKEN="+mocks.ValidAPITokens[0],
+		)
+		if testing.Verbose() {
+			cmd.Stderr = os.Stderr
+		}
+
+		b, err := cmd.Output()
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	assert.Equal(t, strings.TrimLeft(`
++--------------+--------------------------------+-----------------------+
+| Name         | Label                          | Owner email           |
++--------------+--------------------------------+-----------------------+
+| acme         | ACME Inc.                      | user-id-1@example.com |
+| four-seasons | Four Seasons Total Landscaping | user-id-1@example.com |
+| duff         | Duff Beer                      | user-id-2@example.com |
++--------------+--------------------------------+-----------------------+
+`, "\n"), run("orgs"))
+
+	assert.Equal(t, strings.TrimLeft(`
+Name	Label	Owner email
+acme	ACME Inc.	user-id-1@example.com
+four-seasons	Four Seasons Total Landscaping	user-id-1@example.com
+duff	Duff Beer	user-id-2@example.com
+`, "\n"), run("orgs", "--format", "plain"))
+
+	assert.Equal(t, strings.TrimLeft(`
+org-id-1,acme
+org-id-2,four-seasons
+org-id-3,duff
+`, "\n"), run("orgs", "--format", "csv", "--columns", "id,name", "--no-header"))
+}
+
+func orgListServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if testing.Verbose() {
+			t.Log(req)
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/organizations",
+			req.Method == http.MethodGet && regexp.MustCompile(`^/users/[a-z0-9-]+/organizations$`).MatchString(req.URL.Path):
+			makeOrg := func(id, name, label, owner string) org {
+				return org{
+					ID:    id,
+					Name:  name,
+					Label: label,
+					Owner: owner,
+					Links: makeHALLinks("self=/organizations/" + url.PathEscape(id)),
+				}
+			}
+			ownerIDs := []string{"user-id-1", "user-id-2"}
+			_ = json.NewEncoder(w).Encode(struct {
+				Items []org    `json:"items"`
+				Links halLinks `json:"_links"`
+			}{Items: []org{
+				makeOrg("org-id-1", "acme", "ACME Inc.", ownerIDs[0]),
+				makeOrg("org-id-2", "four-seasons", "Four Seasons Total Landscaping", ownerIDs[0]),
+				makeOrg("org-id-3", "duff", "Duff Beer", ownerIDs[1]),
+			}, Links: makeHALLinks("ref:users:0=/ref/users?in=" + strings.Join(ownerIDs, ","))})
+			return
+		// TODO generalize users server
+		case req.Method == http.MethodGet && req.URL.Path == "/users/me":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "user-id"})
+		case req.Method == http.MethodGet && regexp.MustCompile(`^/users/[a-z0-9-]+$`).MatchString(req.URL.Path):
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": path.Base(req.URL.Path)})
+		case req.Method == http.MethodGet && req.URL.Path == "/ref/users":
+			require.NoError(t, req.ParseForm())
+			ids := strings.Split(req.Form.Get("in"), ",")
+			type userRef struct {
+				ID       string `json:"id"`
+				Email    string `json:"email"`
+				Username string `json:"username"`
+			}
+			userRefs := make(map[string]userRef, len(ids))
+			for _, id := range ids {
+				userRefs[id] = userRef{ID: id, Email: id + "@example.com", Username: id}
+			}
+			_ = json.NewEncoder(w).Encode(userRefs)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}

--- a/tests/integration/project_create_test.go
+++ b/tests/integration/project_create_test.go
@@ -2,40 +2,208 @@ package integration
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/platformsh/cli/tests/integration/mocks"
 )
 
+type halLink struct {
+	HREF string `json:"href"`
+}
+
+type halLinks struct {
+	Self halLink `json:"self"`
+}
+
+type subscription struct {
+	ID            string   `json:"id"`
+	Links         halLinks `json:"_links"`
+	ProjectID     string   `json:"project_id"`
+	ProjectRegion string   `json:"project_region"`
+	ProjectTitle  string   `json:"project_title"`
+	Status        string   `json:"status"`
+	ProjectUI     string   `json:"project_ui"`
+
+	eventualProjectID string
+}
+
+type subscriptionsCache struct {
+	subscriptions map[string]*subscription
+	sync.RWMutex
+}
+
+func (c *subscriptionsCache) upsert(s *subscription) {
+	c.Lock()
+	defer c.Unlock()
+	if c.subscriptions == nil {
+		c.subscriptions = make(map[string]*subscription)
+	}
+	c.subscriptions[s.ID] = s
+}
+
+func (c *subscriptionsCache) get(id string) *subscription {
+	c.RLock()
+	defer c.RUnlock()
+	return c.subscriptions[id]
+}
+
+func projectCreateServer(t *testing.T) *httptest.Server {
+	var subscriptions subscriptionsCache
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if testing.Verbose() {
+			t.Log(req)
+		}
+		switch {
+		case req.Method == http.MethodPost &&
+			regexp.MustCompile(`^/organizations/[a-z0-9-]+/subscriptions$`).MatchString(req.URL.Path):
+			var createOptions = struct {
+				Region string `json:"project_region"`
+				Title  string `json:"project_title"`
+			}{}
+			err := json.NewDecoder(req.Body).Decode(&createOptions)
+			require.NoError(t, err)
+			id := fmt.Sprint(rand.Int()) //nolint:gosec
+			s := subscription{
+				ID:                "s" + id,
+				Links:             halLinks{Self: halLink{HREF: "/subscriptions/" + url.PathEscape("s"+id)}},
+				ProjectRegion:     createOptions.Region,
+				ProjectTitle:      createOptions.Title,
+				Status:            "provisioning",
+				eventualProjectID: "p" + id,
+			}
+			subscriptions.upsert(&s)
+			_ = json.NewEncoder(w).Encode(s)
+			return
+		case req.URL.Path == "/me/verification":
+			_ = json.NewEncoder(w).Encode(map[string]any{"state": false, "type": ""})
+			return
+		case req.Method == http.MethodGet && regexp.MustCompile(`^/subscriptions/[a-z0-9-]+$`).MatchString(req.URL.Path):
+			s := subscriptions.get(path.Base(req.URL.Path))
+			if s == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			s.Status = "active"
+			s.ProjectID = s.eventualProjectID
+			s.ProjectUI = "http://console.example.com/projects/" + url.PathEscape(s.eventualProjectID)
+			subscriptions.upsert(s)
+			_ = json.NewEncoder(w).Encode(s)
+			return
+		case req.Method == http.MethodGet && req.URL.Path == "/organizations/name=cli-tests":
+			type org struct {
+				ID    string   `json:"id"`
+				Name  string   `json:"name"`
+				Label string   `json:"label"`
+				Links halLinks `json:"_links"`
+			}
+			_ = json.NewEncoder(w).Encode(org{
+				ID:    "cli-tests",
+				Name:  "cli-tests",
+				Label: "CLI Test Organization",
+				Links: halLinks{Self: halLink{"/organizations/cli-tests"}},
+			})
+			return
+		case req.Method == http.MethodGet && req.URL.Path == "/organizations/cli-tests/setup/options":
+			type options struct {
+				Plans   []string `json:"plans"`
+				Regions []string `json:"regions"`
+			}
+			_ = json.NewEncoder(w).Encode(options{[]string{"development"}, []string{"test-region"}})
+			return
+		case req.Method == http.MethodGet && regexp.MustCompile(`^/projects/[a-z0-9-]+$`).MatchString(req.URL.Path):
+			type repoInfo struct {
+				URL string `json:"url"`
+			}
+			type project struct {
+				ID         string   `json:"id"`
+				Repository repoInfo `json:"repository"`
+				Links      halLinks `json:"_links"`
+			}
+			projectID := path.Base(req.URL.Path)
+			_ = json.NewEncoder(w).Encode(project{
+				ID:         path.Base(req.URL.Path),
+				Links:      halLinks{Self: halLink{req.URL.Path}},
+				Repository: repoInfo{projectID + "@git.example.com:" + projectID + ".git"},
+			})
+			return
+		case req.Method == http.MethodGet && req.URL.Path == "/regions":
+			type region struct {
+				ID             string `json:"id"`
+				Label          string `json:"label"`
+				SelectionLabel string `json:"selection_label"`
+				Available      bool   `json:"available"`
+			}
+			type regions struct {
+				Regions []region `json:"regions"`
+			}
+			_ = json.NewEncoder(w).Encode(regions{[]region{{
+				ID:             "test-region",
+				Label:          "Test Region",
+				SelectionLabel: "Test Region",
+				Available:      true,
+			}}})
+			return
+		case req.Method == http.MethodGet &&
+			regexp.MustCompile(`^/organizations/[a-z0-9-]+/subscriptions/estimate$`).MatchString(req.URL.Path):
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": "$1,000 USD"})
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
 func TestProjectCreate(t *testing.T) {
-	if os.Getenv(EnvPrefix+"TOKEN") == "" {
-		t.Skip("enable by setting " + EnvPrefix + "TOKEN")
-	}
-	region := "eu-3.platform.sh"
-	if v := os.Getenv("TEST_REGION"); v != "" {
-		region = v
-	}
-	org := "cli-tests"
-	if v := os.Getenv("TEST_ORG"); v != "" {
-		region = v
-	}
-	cmd := command(t, "project:create", "--region="+region, "--title=Automated_Test", "--org="+org, "--no-set-remote")
+	authServer := mocks.APITokenServer(t)
+	defer authServer.Close()
+
+	apiServer := projectCreateServer(t)
+	defer apiServer.Close()
+
+	title := "Test Project Title"
+	region := "test-region"
+
+	cmd := command(t, "project:create", "-v", "--region", region, "--title", title, "--org", "cli-tests")
+	cmd.Env = append(
+		cmd.Env,
+		EnvPrefix+"API_BASE_URL="+apiServer.URL,
+		EnvPrefix+"API_AUTH_URL="+authServer.URL,
+		EnvPrefix+"TOKEN=api-token-1",
+	)
+
 	var stdErrBuf bytes.Buffer
 	var stdOutBuf bytes.Buffer
 	cmd.Stderr = &stdErrBuf
-	cmd.Stdout = &stdOutBuf
-	if err := cmd.Run(); err != nil {
-		require.NoError(t, err, "stderr output: "+stdErrBuf.String())
+	if testing.Verbose() {
+		cmd.Stderr = io.MultiWriter(&stdErrBuf, os.Stderr)
 	}
+	cmd.Stdout = &stdOutBuf
+	require.NoError(t, cmd.Run())
 
 	// stdout should contain the project ID.
-	assert.Greater(t, stdOutBuf.Len(), 10)
-	stdout := stdOutBuf.String()
-	projectID := stdout
+	projectID := strings.TrimSpace(stdOutBuf.String())
+	assert.NotEmpty(t, projectID)
 
 	// stderr should contain various messages.
 	stderr := stdErrBuf.String()
+
+	assert.Contains(t, stderr, "The estimated monthly cost of this project is: $1,000 USD")
+	assert.Contains(t, stderr, "Region: "+region)
 	assert.Contains(t, stderr, "Project ID: "+projectID)
+	assert.Contains(t, stderr, "Project title: "+title)
 }


### PR DESCRIPTION
Targeting #210 

This adds tests targeting a few important legacy CLI commands (detailed in commits).

Each command can have its own ad-hoc server providing enough responses so that the command produces useful output.

If/when the number of tests expands this could be refactored in many ways.

Ideally this should run in GitHub but it's in GitLab (where the build works) for now.