### PR TITLE
Clear PHP and .phar cache on failed execution

### DIFF
--- a/internal/legacy/legacy.go
+++ b/internal/legacy/legacy.go
@@ -182,6 +182,9 @@ func (c *CLIWrapper) Exec(ctx context.Context, args ...string) error {
 		c.Version,
 	))
 	if err := cmd.Run(); err != nil {
+		// Cleanup cache directory
+		c.debugLog("removing cache directory: %s", c.cacheDir())
+		os.RemoveAll(c.cacheDir())
 		return fmt.Errorf("could not run legacy CLI command: %w", err)
 	}
 


### PR DESCRIPTION
Lightly resolve issues where PHP binary does not work, especially on Windows
