### PR TITLE
Display errors from setting up temporary files in Init()

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -80,7 +80,7 @@ func newRootCommand(cnf *config.Config, assets *vendorization.VendorAssets) *cob
 				Stdin:              cmd.InOrStdin(),
 			}
 			if err := c.Init(); err != nil {
-				debugLog("%s\n", color.RedString(err.Error()))
+				log.Println(color.RedString(err.Error()))
 				os.Exit(1)
 				return
 			}


### PR DESCRIPTION
Prints a clear error message instead of silently failing:

```
$ go run ./cmd/platform/main.go help | head -n1
Command: help
$
$ platform help | head -n1
Command: help
$
$ chmod u-x /tmp/platform*
$
$ platform help | head -n1
$
$ go run ./cmd/platform/main.go help | head -n1
2024/12/05 16:28:53 could not acquire lock: open /tmp/platformsh-cli-0.0.0-0.0.0/.lock: permission denied
exit status 1
```