### PR TITLE
Rework error and debug handling

### DIFF
--- a/cmd/platform/main.go
+++ b/cmd/platform/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -14,16 +13,16 @@ import (
 )
 
 func main() {
-	log.SetOutput(color.Error)
-
 	// Load configuration.
 	cnfYAML, err := config.LoadYAML()
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 	cnf, err := config.FromYAML(cnfYAML)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	// When Cobra starts, load Viper config from the environment.

--- a/commands/completion.go
+++ b/commands/completion.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -19,9 +18,10 @@ import (
 
 func newCompletionCommand(cnf *config.Config) *cobra.Command {
 	return &cobra.Command{
-		Use:   "completion",
-		Short: "Print the completion script for your shell",
-		Args:  cobra.MaximumNArgs(1),
+		Use:           "completion",
+		Short:         "Print the completion script for your shell",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			completionArgs := []string{"_completion", "-g", "--program", cnf.Application.Executable}
 			if len(args) > 0 {
@@ -33,6 +33,7 @@ func newCompletionCommand(cnf *config.Config) *cobra.Command {
 				Version:            version,
 				CustomPharPath:     viper.GetString("phar-path"),
 				Debug:              viper.GetBool("debug"),
+				DebugLogFunc:       debugLog,
 				DisableInteraction: viper.GetBool("no-interaction"),
 				Stdout:             &b,
 				Stderr:             cmd.ErrOrStderr(),
@@ -40,13 +41,13 @@ func newCompletionCommand(cnf *config.Config) *cobra.Command {
 			}
 
 			if err := c.Init(); err != nil {
-				debugLog("%s\n", color.RedString(err.Error()))
+				debugLog(err.Error())
 				os.Exit(1)
 				return
 			}
 
 			if err := c.Exec(cmd.Context(), completionArgs...); err != nil {
-				debugLog("%s\n", color.RedString(err.Error()))
+				debugLog(err.Error())
 				exitCode := 1
 				var execErr *exec.ExitError
 				if errors.As(err, &execErr) {


### PR DESCRIPTION
Choices:
- Do not silence Cobra errors
- Remove stdlib log use
- Make debug logging consistent with legacy CLI format
- Consistently use Cobra command output writers, and make them colorable when possible

Rationale:
- DX issues found when implementing #226 (this PR is extracted from that, to reduce its size)
- Various issues were caused by silencing errors, like #177 and #222
- The `color` package wants a colorable output writer to be used, but we sometimes need to replace `os.Stderr` with `io.Discard` in the root command so that the `--quiet` option works, so we need output to go through the Cobra `cmd` writers.
- I find `log` timestamps distracting: if I wanted timestamps I would pipe output to `ts`. Of course timestamps would be essential when logging to a file.