### PR TITLE
Fix Windows curl and openssl config

### DIFF
--- a/internal/legacy/php_windows.go
+++ b/internal/legacy/php_windows.go
@@ -68,5 +68,11 @@ func (c *CLIWrapper) PHPPath() string {
 }
 
 func (c *CLIWrapper) phpSettings() []string {
-	return []string{"openssl.cafile", path.Join(c.cacheDir(), "php", "extras", "cacert.pem")}
+	cacheDir := c.cacheDir()
+
+	return []string{
+		"extension=" + filepath.Join(cacheDir, "php", "ext", "php_curl.dll"),
+		"extension=" + filepath.Join(cacheDir, "php", "ext", "php_openssl.dll"),
+		"openssl.cafile=" + filepath.Join(cacheDir, "php", "extras", "cacert.pem"),
+	}
 }


### PR DESCRIPTION
Caused by #231 - after deleting `%USERPROFILE%\.platformsh\credential-helper.exe`, the CLI will fail to re-download the credential helper due to openssl being disabled.

Manually tested on Windows 11 Home (plain install + Scoop + `vcredist` +  Command Prompt)