### PR TITLE
Bump Platformify to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/gofrs/flock v0.12.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/platformsh/platformify v0.3.1
+	github.com/platformsh/platformify v0.4.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -90,10 +90,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/platformsh/platformify v0.3.0 h1:ZxIpgmgPUuA50RRZe/gCYbud2piTebbMf2wW35VR1w0=
-github.com/platformsh/platformify v0.3.0/go.mod h1:fgmCcfQfHbhe1oXsIdIhpnniyZu8IdIMOlcBAa/ygic=
-github.com/platformsh/platformify v0.3.1 h1:n5Sgp2TuND6tVC41smg3WXuIU3EALYxXXoOGghT3FAY=
-github.com/platformsh/platformify v0.3.1/go.mod h1:fgmCcfQfHbhe1oXsIdIhpnniyZu8IdIMOlcBAa/ygic=
+github.com/platformsh/platformify v0.4.0 h1:OMWjSsM8RwZN9lZuRdQD/URicy+OyKhNLMrca1JBlNg=
+github.com/platformsh/platformify v0.4.0/go.mod h1:fgmCcfQfHbhe1oXsIdIhpnniyZu8IdIMOlcBAa/ygic=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## What's Changed
* schema: allow integer in "expires" values by @pjcdawkins in https://github.com/platformsh/platformify/pull/246
* Remove enum variants from boolean fields in the Upsun JSON schema, by @cborup in https://github.com/platformsh/platformify/pull/247
* Remove the Lisp runtime by @fabpot in https://github.com/platformsh/platformify/pull/249
* schema: allow the 'type' property for composable images by @pjcdawkins in https://github.com/platformsh/platformify/pull/250

## New Contributors
* @cborup made their first contribution in https://github.com/platformsh/platformify/pull/247
* @fabpot made their first contribution in https://github.com/platformsh/platformify/pull/249

**Full Changelog**: https://github.com/platformsh/platformify/compare/v0.3.1...v0.4.0