### PR TITLE
Updates embeded links to the docs.* sites to permalink structure

### DIFF
--- a/.goreleaser.vendor.yaml.tpl
+++ b/.goreleaser.vendor.yaml.tpl
@@ -75,7 +75,7 @@ archives:
         format: zip
 
 nfpms:
-  - homepage: https://docs.platform.sh/administration/cli.html
+  - homepage: https://docs.upsun.com/anchors/fixed/cli/
     package_name: ${VENDOR_BINARY}-cli
     description: ${VENDOR_NAME} CLI
     maintainer: Antonis Kalipetis <antonis.kalipetis@platform.sh>

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -216,7 +216,7 @@ brews:
       name: Antonis Kalipetis
       email: antonis.kalipetis@platform.sh
 
-    homepage: https://docs.platform.sh/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/fixed/cli/
     description: Platform.sh CLI
     license: MIT
 
@@ -246,7 +246,7 @@ brews:
       name: Antonis Kalipetis
       email: antonis.kalipetis@platform.sh
 
-    homepage: https://docs.upsun.com/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/cli/
     description: Upsun CLI
     license: MIT
 
@@ -275,7 +275,7 @@ scoops:
       name: Antonis Kalipetis
       email: antonis.kalipetis@platform.sh
 
-    homepage: https://docs.platform.sh/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/fixed/cli/
     description: Platform.sh CLI
     license: MIT
 
@@ -296,7 +296,7 @@ scoops:
       name: Antonis Kalipetis
       email: antonis.kalipetis@platform.sh
 
-    homepage: https://docs.upsun.com/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/cli/
     description: Upsun CLI
     license: MIT
 
@@ -306,7 +306,7 @@ scoops:
 
 nfpms:
   - id: platform
-    homepage: https://docs.platform.sh/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/fixed/cli/
     package_name: platformsh-cli
     description: Platform.sh CLI
     maintainer: Antonis Kalipetis <antonis.kalipetis@platform.sh>
@@ -325,7 +325,7 @@ nfpms:
         dst: /usr/local/share/zsh/site-functions/_platform
 
   - id: upsun
-    homepage: https://docs.upsun.com/administration/cli.html
+    homepage: https://docs.upsun.com/anchors/cli/
     package_name: upsun-cli
     description: Upsun CLI
     maintainer: Antonis Kalipetis <antonis.kalipetis@platform.sh>

--- a/internal/config/platformsh-cli.yaml
+++ b/internal/config/platformsh-cli.yaml
@@ -47,9 +47,9 @@ service:
 
   pricing_url: 'https://platform.sh/pricing'
 
-  activity_type_list_url: 'https://docs.platform.sh/integrations/activity/reference.html#type'
+  activity_type_list_url: 'https://docs.upsun.com/anchors/fixed/integrations/activity-scripts/type/'
 
-  runtime_operations_help_url: 'https://docs.platform.sh/create-apps/runtime-operations.html'
+  runtime_operations_help_url: 'https://docs.upsun.com/anchors/fixed/app/runtime-operations/'
 
 api:
   base_url: 'https://api.platform.sh'
@@ -75,7 +75,7 @@ detection:
 
 migrate:
   prompt: true
-  docs_url: https://docs.platform.sh/administration/cli.html
+  docs_url: https://docs.upsun.com/anchors/fixed/cli/
 
 warnings:
   non_production_domains_msg: |
@@ -83,4 +83,4 @@ warnings:
     If you're an Enterprise or Elite customer, contact support to enable the feature.
     Otherwise contact sales first to upgrade your plan.
 
-    See: https://docs.platform.sh/overview/get-support.html
+    See: https://docs.upsun.com/anchors/fixed/get-support/

--- a/internal/config/upsun-cli.yaml
+++ b/internal/config/upsun-cli.yaml
@@ -46,9 +46,9 @@ service:
 
   pricing_url: "https://upsun.com/pricing"
 
-  activity_type_list_url: "https://docs.upsun.com/integrations/activity/reference.html#type"
+  activity_type_list_url: "https://docs.upsun.com/anchors/integrations/activity-scripts/type/"
 
-  runtime_operations_help_url: "https://docs.upsun.com/create-apps/runtime-operations.html"
+  runtime_operations_help_url: "https://docs.upsun.com/anchors/app/runtime-operations/"
 
 api:
   base_url: "https://api.upsun.com"


### PR DESCRIPTION
Closes #258 

Updates embedded links to the docs.(platform.sh|upsun.com) sites to the new permalink structure. See announcement for context: https://platformsh.slack.com/archives/C09MDEPL4/p1755024969347679 

For reference the `fixed` path component is a redirection to what is currently docs.platform.sh. _When_ the two docs sites are merged into one, the permalink will be updated to the then correct location. 