### PR TITLE
Introduce authenticated client in Go using the Legacy CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/symfony-cli/terminal v1.0.7
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/crypto v0.37.0
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/platformsh/cli/internal/legacy"
+	"golang.org/x/oauth2"
+)
+
+func NewLegacyCLIClient(ctx context.Context, wrapper *legacy.CLIWrapper) (*http.Client, error) {
+	ts, err := NewLegacyCLITokenSource(ctx, wrapper)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: create token source: %w", err)
+	}
+
+	refresher := ts.(refresher)
+	baseRT := http.DefaultTransport
+	if rt, ok := TransportFromContext(ctx); ok && rt != nil {
+		baseRT = rt
+	}
+	return &http.Client{
+		Transport: &Transport{
+			refresher: refresher,
+			base: &oauth2.Transport{
+				Source: ts,
+				Base:   baseRT,
+			},
+			wrapper: wrapper,
+		},
+	}, nil
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// jwtClaims represents the expected claims contained in the JWT token.
+type jwtClaims struct {
+	AccessID           string         `json:"access_id"`
+	Actor              map[string]any `json:"act,omitempty"`
+	AuthMethods        []string       `json:"amr,omitempty"`
+	AuthenticationTime int64          `json:"auth_time,omitempty"`
+	ClientID           string         `json:"cid,omitempty"`
+	ExpiresAt          int64          `json:"exp,omitempty"`
+	GrantType          string         `json:"grant,omitempty"`
+	IssuedAt           int64          `json:"iat,omitempty"`
+	Issuer             string         `json:"iss,omitempty"`
+	JWTID              string         `json:"jti,omitempty"`
+	NotBefore          int64          `json:"nbf,omitempty"`
+	Namespace          string         `json:"ns,omitempty"`
+	Scopes             []string       `json:"scp,omitempty"`
+	Subject            string         `json:"sub,omitempty"`
+}
+
+// unsafeParseJWT parses a JWT without verifying its signature and returns its claims.
+// WARNING: This is intentionally unsafe and must not be used for trust decisions.
+func unsafeParseJWT(token string) (*jwtClaims, error) {
+	if token == "" {
+		return nil, errors.New("jwt: empty token")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("jwt: malformed token, expected 3 parts, got %d", len(parts))
+	}
+	payloadSeg := parts[1]
+
+	// Base64 URL decode without padding as per RFC 7515.
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(payloadSeg)
+	if err != nil {
+		return nil, fmt.Errorf("jwt: decode payload: %w", err)
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, fmt.Errorf("jwt: unmarshal claims: %w", err)
+	}
+	return &claims, nil
+}

--- a/internal/auth/legacy.go
+++ b/internal/auth/legacy.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/platformsh/cli/internal/legacy"
+	"golang.org/x/oauth2"
+)
+
+type legacyCLITokenSource struct {
+	ctx     context.Context
+	cached  *oauth2.Token
+	wrapper *legacy.CLIWrapper
+	mu      sync.Mutex
+}
+
+func (ts *legacyCLITokenSource) getLegacyCLIToken() (*oauth2.Token, error) {
+	bt := bytes.NewBuffer(nil)
+	ts.wrapper.Stdout = bt
+	if err := ts.wrapper.Exec(ts.ctx, "auth:token", "-W"); err != nil {
+		return nil, fmt.Errorf("cannot retrieve token: %w", err)
+	}
+
+	at, err := unsafeParseJWT(bt.String())
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse token: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: bt.String(),
+		TokenType:   "Bearer",
+		Expiry:      time.Unix(at.ExpiresAt, 0),
+	}, nil
+}
+
+func (ts *legacyCLITokenSource) refreshToken() error {
+	ts.cached = nil
+	ts.wrapper.Stdout = io.Discard
+	if err := ts.wrapper.Exec(ts.ctx, "auth:info", "--refresh"); err != nil {
+		return fmt.Errorf("cannot refresh token: %w", err)
+	}
+
+	return nil
+}
+
+func (ts *legacyCLITokenSource) invalidateToken() error {
+	if ts.cached != nil {
+		ts.cached.AccessToken = ""
+	}
+
+	return nil
+}
+
+func (ts *legacyCLITokenSource) Token() (*oauth2.Token, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if ts.cached == nil {
+		tok, err := ts.getLegacyCLIToken()
+		if err != nil {
+			return nil, err
+		}
+		ts.cached = tok
+	}
+
+	if ts.cached != nil && ts.cached.Valid() {
+		return ts.cached, nil
+	}
+
+	if err := ts.refreshToken(); err != nil {
+		return nil, err
+	}
+
+	tok, err := ts.getLegacyCLIToken()
+	if err != nil {
+		return nil, err
+	}
+
+	ts.cached = tok
+	return ts.cached, nil
+}
+
+func NewLegacyCLITokenSource(ctx context.Context, wrapper *legacy.CLIWrapper) (oauth2.TokenSource, error) {
+	wrapper.ForceColor = true
+	wrapper.DisableInteraction = true
+	return &legacyCLITokenSource{
+		ctx:     ctx,
+		wrapper: wrapper,
+	}, nil
+}

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/platformsh/cli/internal/legacy"
+)
+
+type refresher interface {
+	refreshToken() error
+	invalidateToken() error
+}
+
+// Transport is an HTTP RoundTripper similar to golang.org/x/oauth2.Transport.
+// It injects Authorization headers using a savingSource and, on a 401 response,
+// clears the cached token and retries the request once.
+type Transport struct {
+	// base is the underlying oauth2.Transport that adds the Authorization header.
+	base http.RoundTripper
+
+	// refresher is the savingSource used as the TokenSource for base; kept private
+	// so we can clear its cached token on 401.
+	refresher refresher
+
+	wrapper *legacy.CLIWrapper
+}
+
+// RoundTrip adds Authorization via the underlying oauth2.Transport. If the
+// response is 401 Unauthorized, it clears the cached token and retries once.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Body = wrapReader(req.Body)
+
+	resp, err := t.base.RoundTrip(req)
+
+	// Retry on 401
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		fmt.Fprintln(os.Stderr, "401: refreshing token...")
+		t.refresher.invalidateToken()
+		flushReader(resp.Body)
+		resp, err = t.base.RoundTrip(req)
+	}
+
+	if errors.Is(err, ErrNoValidCredentials) {
+		fmt.Fprintln(os.Stderr, "invalid credentials: re-authenticating...")
+		t.refresher.refreshToken()
+		resp, err = t.base.RoundTrip(req)
+	}
+
+	return resp, err
+}
+
+// context key for storing a custom RoundTripper.
+type transportCtxKey struct{}
+
+// WithTransport returns a new context that carries the provided RoundTripper.
+func WithTransport(ctx context.Context, rt http.RoundTripper) context.Context {
+	return context.WithValue(ctx, transportCtxKey{}, rt)
+}
+
+// TransportFromContext retrieves a RoundTripper previously stored with
+// WithTransport. It returns (nil, false) if none is set.
+func TransportFromContext(ctx context.Context) (http.RoundTripper, bool) {
+	v := ctx.Value(transportCtxKey{})
+	if v == nil {
+		return nil, false
+	}
+	rt, ok := v.(http.RoundTripper)
+	if !ok || rt == nil {
+		return nil, false
+	}
+	return rt, true
+}
+
+func wrapReader(r io.ReadCloser) io.ReadCloser {
+	if r == nil {
+		return nil
+	}
+	bodyBytes, _ := io.ReadAll(r)
+	_ = r.Close()
+	return io.NopCloser(bytes.NewBuffer(bodyBytes))
+}
+
+func flushReader(r io.ReadCloser) {
+	if r == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, r)
+	_ = r.Close()
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -45,8 +45,10 @@ type Config struct {
 		BaseURL string `validate:"required,url" yaml:"base_url"`            // e.g. "https://api.platform.sh"
 		AuthURL string `validate:"omitempty,url" yaml:"auth_url,omitempty"` // e.g. "https://auth.api.platform.sh"
 
-		UserAgent string `validate:"omitempty" yaml:"user_agent,omitempty"` // a template - see UserAgent method
+		UserAgent string `validate:"omitempty" yaml:"user_agent,omitempty"`       // a template - see UserAgent method
+		SessionID string `validate:"omitempty,ascii" yaml:"session_id,omitempty"` // the ID for the authentication session - defaults to "default"
 
+		OAuth2ClientID     string `validate:"required_without=AuthURL,omitempty" yaml:"oauth2_client_id,omitempty"`      // e.g. "upsun-cli"
 		OAuth2AuthorizeURL string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_auth_url,omitempty"`   // e.g. "https://auth.api.platform.sh/oauth2/authorize"
 		OAuth2RevokeURL    string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_revoke_url,omitempty"` // e.g. "https://auth.api.platform.sh/oauth2/revoke"
 		OAuth2TokenURL     string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_token_url,omitempty"`  // e.g. "https://auth.api.platform.sh/oauth2/token"

--- a/internal/legacy/legacy.go
+++ b/internal/legacy/legacy.go
@@ -39,6 +39,7 @@ type CLIWrapper struct {
 	Version            string
 	Debug              bool
 	DisableInteraction bool
+	ForceColor         bool
 	DebugLogFunc       func(string, ...any)
 
 	initOnce  sync.Once
@@ -158,6 +159,9 @@ func (c *CLIWrapper) Exec(ctx context.Context, args ...string) error {
 	)
 	if c.DisableInteraction {
 		cmd.Env = append(cmd.Env, envPrefix+"NO_INTERACTION=1")
+	}
+	if c.ForceColor {
+		cmd.Env = append(cmd.Env, "CLICOLOR_FORCE=1")
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf(
 		"%sUSER_AGENT={APP_NAME_DASH}/%s ({UNAME_S}; {UNAME_R}; PHP %s; WRAPPER %s)",


### PR DESCRIPTION
1. Use the Legacy CLI for getting a token
2. If the token is not valid (ie expired), force re-authentication
3. If the client receives a 401 response, force re-authentication