### PR TITLE
Upgrade golangci-lint to version 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
           touch internal/config/embedded-config.yaml
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.4
+          args: --timeout=5m
 
       - name: Run tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,142 +1,75 @@
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: true
-  goconst:
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-      - emptyStringTest
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/platformsh/cli
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 120
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
-  nolintlint:
-    # Enable to ensure that nolint directives are all used. Default is true.
-    allow-unused: false
-    # Require to specify linter that is being skipped. Default is false
-    require-specific: true
-  prealloc:
-    # Report preallocation suggestions on for loops, false by default
-    for-loops: true
-
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
-    # Simple linter to check that your code does not contain non-ASCII identifiers
-    # - asciicheck
-    # checks whether HTTP response body is closed successfully
     - bodyclose
-    # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - dogsled
-    # Tool for code clone detection
-    # - dupl
-    # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - errcheck
-    # Tool for detection of long functions
-    # - funlen
-    # Checks that no globals are present in Go code
-    # - gochecknoglobals
-    # Checks that no init functions are present in Go code
-    # - gochecknoinits
-    # Computes and checks the cognitive complexity of functions
-    # - gocognit
-    # Finds repeated strings that could be replaced by a constant
     - goconst
-    # The most opinionated Go source code linter
     - gocritic
-    # Computes and checks the cyclomatic complexity of functions
-    # - gocyclo
-    # Check if comments end in a period
-    # - godot
-    # Tool for detection of FIXME, TODO and other comment keywords
-    # - godox
-    # Golang linter to check the errors handling expressions
-    # - goerr113
-    # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gofmt
-    # Goimports does everything that gofmt does. Additionally, it checks unused imports
-    - goimports
-    # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - revive
-    # An analyzer to detect magic numbers.
-    # - gomnd
-    # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
-    # - gomodguard
-    # Checks that printf-like functions are named with f at the end
     - goprintffuncname
-    # Inspects source code for security problems
     - gosec
-    # Linter for Go source code that specializes in simplifying a code
-    - gosimple
-    # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - govet
-    # Detects when assignments to existing variables are not used
     - ineffassign
-    # Linter that suggests narrower interface types
-    # - interfacer
-    # Reports long lines
     - lll
-    # Tool to detect Go structs that would take less memory if their fields were sorted
-    # - maligned
-    # Finds commonly misspelled English words in comments
     - misspell
-    # (?) Finds naked returns in functions greater than a specified function length
     - nakedret
-    # Reports deeply nested if statements
-    # - nestif
-    # Reports ill-formed or insufficient nolint directives
     - nolintlint
-    # Finds slice declarations that could potentially be preallocated
     - prealloc
-    # Find code that shadows one of Go's predeclared identifiers.
     - predeclared
-    # checks whether Err of rows is checked successfully
-    # rowserrcheck is disabled because of generics. See https://github.com/golangci/golangci-lint/issues/2649.
-    # - rowserrcheck
-    # Scopelint checks for unpinned variables in go programs
-    # - scopelint
-    # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - revive
     - staticcheck
-    # Stylecheck is a replacement for golint
-    - stylecheck
-    # linter that makes you use a separate _test package
-    # - testpackage
-    # Like the front-end of a Go compiler, parses and type-checks Go code
-    - typecheck
-    # Remove unnecessary type conversions
     - unconvert
-    # (?) Reports unused function parameters
-    # - unparam
-    # Checks Go code for unused constants, variables, functions and types
     - unused
-    # Tool for detection of leading and trailing whitespace
     - whitespace
-    # Whitespace Linter - Forces you to use empty lines!
-    # - wsl
-
-issues:
-  exclude-dirs:
-    - vendor
+  settings:
+    errcheck:
+      check-type-assertions: true
+    goconst:
+      min-occurrences: 5
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+        - emptyStringTest
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    lll:
+      line-length: 120
+    misspell:
+      locale: US
+    nolintlint:
+      require-specific: true
+      allow-unused: false
+    prealloc:
+      for-loops: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/platformsh/cli
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ VERSION := $(shell git describe --always)
 
 # Tooling versions
 GORELEASER_VERSION=v1.26
-GOLANGCI_LINT_VERSION=v1.64
 
 internal/legacy/archives/platform.phar:
 	curl -L https://github.com/platformsh/legacy-cli/releases/download/v$(LEGACY_CLI_VERSION)/platform.phar -o internal/legacy/archives/platform.phar
@@ -93,12 +92,9 @@ test: ## Run unit tests
 	go clean -testcache
 	go test -v -race -mod=readonly -cover ./...
 
-golangci-lint:
-	command -v golangci-lint >/dev/null || go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-
 .PHONY: lint
-lint: golangci-lint ## Run linter
-	golangci-lint run --timeout=10m --verbose
+lint: ## Run linter
+	golangci-lint run --timeout=5m --verbose
 
 .goreleaser.vendor.yaml: check-vendor ## Generate the goreleaser vendor config
 	cat .goreleaser.vendor.yaml.tpl | envsubst > .goreleaser.vendor.yaml

--- a/internal/config/alt/alt.go
+++ b/internal/config/alt/alt.go
@@ -43,7 +43,7 @@ func (a *Alt) GenerateAndSave() error {
 }
 
 func (a *Alt) generateExecutable() string {
-	if runtime.GOOS == "windows" { //nolint:goconst
+	if runtime.GOOS == "windows" {
 		return ":: " + a.comment + "\r\n" +
 			"@echo off\r\n" +
 			"setlocal\r\n" +

--- a/internal/config/alt/fetch.go
+++ b/internal/config/alt/fetch.go
@@ -19,6 +19,8 @@ import (
 // needing to know the whole schema, and to preserve comments. A comment and some
 // metadata are added to the cnfNode. A "cnfStruct" is also returned to allow
 // reading some keys.
+//
+//nolint:gocritic // The "importShadow" rule complains about the url parameter.
 func FetchConfig(ctx context.Context, url string) (cnfNode *yaml.Node, cnfStruct *config.Config, err error) {
 	if err := validateConfigURL(url); err != nil {
 		return nil, nil, err

--- a/internal/config/alt/fs_test.go
+++ b/internal/config/alt/fs_test.go
@@ -15,7 +15,7 @@ func TestFindConfigDir(t *testing.T) {
 
 	t.Run("XDG_CONFIG_HOME exists", func(t *testing.T) {
 		switch runtime.GOOS {
-		case "windows", "darwin", "ios", "plan9":
+		case "windows", "darwin", "ios", "plan9": //nolint:goconst
 			t.Skip()
 		}
 		err := os.Setenv("XDG_CONFIG_HOME", tempDir)

--- a/pkg/mockapi/activities.go
+++ b/pkg/mockapi/activities.go
@@ -9,11 +9,11 @@ import (
 )
 
 func (h *Handler) handleListProjectActivities(w http.ResponseWriter, req *http.Request) {
-	h.store.RLock()
-	defer h.store.RUnlock()
+	h.RLock()
+	defer h.RUnlock()
 	projectID := chi.URLParam(req, "project_id")
-	var activities = make([]*Activity, 0, len(h.store.activities[projectID]))
-	for _, a := range h.store.activities[projectID] {
+	var activities = make([]*Activity, 0, len(h.activities[projectID]))
+	for _, a := range h.activities[projectID] {
 		activities = append(activities, a)
 	}
 	// Sort activities in descending order by created date.
@@ -22,11 +22,11 @@ func (h *Handler) handleListProjectActivities(w http.ResponseWriter, req *http.R
 }
 
 func (h *Handler) handleGetProjectActivity(w http.ResponseWriter, req *http.Request) {
-	h.store.RLock()
-	defer h.store.RUnlock()
+	h.RLock()
+	defer h.RUnlock()
 	projectID := chi.URLParam(req, "project_id")
 	activityID := chi.URLParam(req, "id")
-	if projectActivities := h.store.activities[projectID]; projectActivities != nil {
+	if projectActivities := h.activities[projectID]; projectActivities != nil {
 		_ = json.NewEncoder(w).Encode(projectActivities[activityID])
 		return
 	}
@@ -34,12 +34,12 @@ func (h *Handler) handleGetProjectActivity(w http.ResponseWriter, req *http.Requ
 }
 
 func (h *Handler) handleListEnvironmentActivities(w http.ResponseWriter, req *http.Request) {
-	h.store.RLock()
-	defer h.store.RUnlock()
+	h.RLock()
+	defer h.RUnlock()
 	projectID := chi.URLParam(req, "project_id")
 	environmentID := chi.URLParam(req, "environment_id")
-	var activities = make([]*Activity, 0, len(h.store.activities[projectID]))
-	for _, a := range h.store.activities[projectID] {
+	var activities = make([]*Activity, 0, len(h.activities[projectID]))
+	for _, a := range h.activities[projectID] {
 		if slices.Contains(a.Environments, environmentID) {
 			activities = append(activities, a)
 		}
@@ -50,11 +50,11 @@ func (h *Handler) handleListEnvironmentActivities(w http.ResponseWriter, req *ht
 }
 
 func (h *Handler) handleGetEnvironmentActivity(w http.ResponseWriter, req *http.Request) {
-	h.store.RLock()
-	defer h.store.RUnlock()
+	h.RLock()
+	defer h.RUnlock()
 	projectID := chi.URLParam(req, "project_id")
 	activityID := chi.URLParam(req, "id")
-	if projectActivities := h.store.activities[projectID]; projectActivities != nil {
+	if projectActivities := h.activities[projectID]; projectActivities != nil {
 		environmentID := chi.URLParam(req, "environment_id")
 		a := projectActivities[activityID]
 		if a == nil || !slices.Contains(a.Environments, environmentID) {

--- a/pkg/mockapi/api_server.go
+++ b/pkg/mockapi/api_server.go
@@ -25,10 +25,10 @@ func NewHandler(t *testing.T) *Handler {
 	h.Mux = chi.NewRouter()
 
 	if testing.Verbose() {
-		h.Mux.Use(middleware.DefaultLogger)
+		h.Use(middleware.DefaultLogger)
 	}
 
-	h.Mux.Use(func(next http.Handler) http.Handler {
+	h.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			authHeader := req.Header.Get("Authorization")
 			require.NotEmpty(t, authHeader)
@@ -37,64 +37,64 @@ func NewHandler(t *testing.T) *Handler {
 		})
 	})
 
-	h.Mux.Get("/users/me", h.handleUsersMe)
-	h.Mux.Get("/users/{user_id}/extended-access", h.handleUserExtendedAccess)
-	h.Mux.Get("/ref/users", h.handleUserRefs)
-	h.Mux.Post("/me/verification", func(w http.ResponseWriter, _ *http.Request) {
+	h.Get("/users/me", h.handleUsersMe)
+	h.Get("/users/{user_id}/extended-access", h.handleUserExtendedAccess)
+	h.Get("/ref/users", h.handleUserRefs)
+	h.Post("/me/verification", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"state": false, "type": ""})
 	})
 
-	h.Mux.Get("/organizations", h.handleListOrgs)
-	h.Mux.Post("/organizations", h.handleCreateOrg)
-	h.Mux.Get("/organizations/{organization_id}", h.handleGetOrg)
-	h.Mux.Patch("/organizations/{organization_id}", h.handlePatchOrg)
-	h.Mux.Get("/users/{user_id}/organizations", h.handleListOrgs)
-	h.Mux.Get("/ref/organizations", h.handleOrgRefs)
+	h.Get("/organizations", h.handleListOrgs)
+	h.Post("/organizations", h.handleCreateOrg)
+	h.Get("/organizations/{organization_id}", h.handleGetOrg)
+	h.Patch("/organizations/{organization_id}", h.handlePatchOrg)
+	h.Get("/users/{user_id}/organizations", h.handleListOrgs)
+	h.Get("/ref/organizations", h.handleOrgRefs)
 
-	h.Mux.Post("/organizations/{organization_id}/subscriptions", h.handleCreateSubscription)
-	h.Mux.Get("/subscriptions/{subscription_id}", h.handleGetSubscription)
-	h.Mux.Get("/organizations/{organization_id}/subscriptions/{subscription_id}", h.handleGetSubscription)
-	h.Mux.Get("/organizations/{organization_id}/subscriptions/can-create", h.handleCanCreateSubscriptions)
-	h.Mux.Get("/organizations/{organization_id}/setup/options", func(w http.ResponseWriter, _ *http.Request) {
+	h.Post("/organizations/{organization_id}/subscriptions", h.handleCreateSubscription)
+	h.Get("/subscriptions/{subscription_id}", h.handleGetSubscription)
+	h.Get("/organizations/{organization_id}/subscriptions/{subscription_id}", h.handleGetSubscription)
+	h.Get("/organizations/{organization_id}/subscriptions/can-create", h.handleCanCreateSubscriptions)
+	h.Get("/organizations/{organization_id}/setup/options", func(w http.ResponseWriter, _ *http.Request) {
 		type options struct {
 			Plans   []string `json:"plans"`
 			Regions []string `json:"regions"`
 		}
 		_ = json.NewEncoder(w).Encode(options{[]string{"development"}, []string{"test-region"}})
 	})
-	h.Mux.Get("/organizations/{organization_id}/subscriptions/estimate", func(w http.ResponseWriter, _ *http.Request) {
+	h.Get("/organizations/{organization_id}/subscriptions/estimate", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"total": "$1,000 USD"})
 	})
 
-	h.Mux.Get("/projects/{project_id}", h.handleGetProject)
-	h.Mux.Patch("/projects/{project_id}", h.handlePatchProject)
-	h.Mux.Get("/projects/{project_id}/environments", h.handleListEnvironments)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}", h.handleGetEnvironment)
-	h.Mux.Patch("/projects/{project_id}/environments/{environment_id}", h.handlePatchEnvironment)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/settings", h.handleGetEnvironmentSettings)
-	h.Mux.Patch("/projects/{project_id}/environments/{environment_id}/settings", h.handleSetEnvironmentSettings)
-	h.Mux.Post("/projects/{project_id}/environments/{environment_id}/deploy", h.handleDeployEnvironment)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/backups", h.handleListBackups)
-	h.Mux.Post("/projects/{project_id}/environments/{environment_id}/backups", h.handleCreateBackup)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/deployments/current", h.handleGetCurrentDeployment)
-	h.Mux.Get("/projects/{project_id}/user-access", h.handleProjectUserAccess)
-	h.Mux.Get("/ref/projects", h.handleProjectRefs)
+	h.Get("/projects/{project_id}", h.handleGetProject)
+	h.Patch("/projects/{project_id}", h.handlePatchProject)
+	h.Get("/projects/{project_id}/environments", h.handleListEnvironments)
+	h.Get("/projects/{project_id}/environments/{environment_id}", h.handleGetEnvironment)
+	h.Patch("/projects/{project_id}/environments/{environment_id}", h.handlePatchEnvironment)
+	h.Get("/projects/{project_id}/environments/{environment_id}/settings", h.handleGetEnvironmentSettings)
+	h.Patch("/projects/{project_id}/environments/{environment_id}/settings", h.handleSetEnvironmentSettings)
+	h.Post("/projects/{project_id}/environments/{environment_id}/deploy", h.handleDeployEnvironment)
+	h.Get("/projects/{project_id}/environments/{environment_id}/backups", h.handleListBackups)
+	h.Post("/projects/{project_id}/environments/{environment_id}/backups", h.handleCreateBackup)
+	h.Get("/projects/{project_id}/environments/{environment_id}/deployments/current", h.handleGetCurrentDeployment)
+	h.Get("/projects/{project_id}/user-access", h.handleProjectUserAccess)
+	h.Get("/ref/projects", h.handleProjectRefs)
 
-	h.Mux.Get("/regions", h.handleListRegions)
+	h.Get("/regions", h.handleListRegions)
 
-	h.Mux.Get("/projects/{project_id}/activities", h.handleListProjectActivities)
-	h.Mux.Get("/projects/{project_id}/activities/{id}", h.handleGetProjectActivity)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/activities", h.handleListEnvironmentActivities)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/activities/{id}", h.handleGetEnvironmentActivity)
+	h.Get("/projects/{project_id}/activities", h.handleListProjectActivities)
+	h.Get("/projects/{project_id}/activities/{id}", h.handleGetProjectActivity)
+	h.Get("/projects/{project_id}/environments/{environment_id}/activities", h.handleListEnvironmentActivities)
+	h.Get("/projects/{project_id}/environments/{environment_id}/activities/{id}", h.handleGetEnvironmentActivity)
 
-	h.Mux.Get("/projects/{project_id}/variables", h.handleListProjectVariables)
-	h.Mux.Post("/projects/{project_id}/variables", h.handleCreateProjectVariable)
-	h.Mux.Get("/projects/{project_id}/variables/{name}", h.handleGetProjectVariable)
-	h.Mux.Patch("/projects/{project_id}/variables/{name}", h.handlePatchProjectVariable)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/variables", h.handleListEnvLevelVariables)
-	h.Mux.Post("/projects/{project_id}/environments/{environment_id}/variables", h.handleCreateEnvLevelVariable)
-	h.Mux.Get("/projects/{project_id}/environments/{environment_id}/variables/{name}", h.handleGetEnvLevelVariable)
-	h.Mux.Patch("/projects/{project_id}/environments/{environment_id}/variables/{name}", h.handlePatchEnvLevelVariable)
+	h.Get("/projects/{project_id}/variables", h.handleListProjectVariables)
+	h.Post("/projects/{project_id}/variables", h.handleCreateProjectVariable)
+	h.Get("/projects/{project_id}/variables/{name}", h.handleGetProjectVariable)
+	h.Patch("/projects/{project_id}/variables/{name}", h.handlePatchProjectVariable)
+	h.Get("/projects/{project_id}/environments/{environment_id}/variables", h.handleListEnvLevelVariables)
+	h.Post("/projects/{project_id}/environments/{environment_id}/variables", h.handleCreateEnvLevelVariable)
+	h.Get("/projects/{project_id}/environments/{environment_id}/variables/{name}", h.handleGetEnvLevelVariable)
+	h.Patch("/projects/{project_id}/environments/{environment_id}/variables/{name}", h.handlePatchEnvLevelVariable)
 
 	return h
 }

--- a/pkg/mockapi/users.go
+++ b/pkg/mockapi/users.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *Handler) handleUsersMe(w http.ResponseWriter, _ *http.Request) {
-	_ = json.NewEncoder(w).Encode(h.store.myUser)
+	_ = json.NewEncoder(w).Encode(h.myUser)
 }
 
 func (h *Handler) handleUserRefs(w http.ResponseWriter, req *http.Request) {
@@ -24,17 +24,17 @@ func (h *Handler) handleUserRefs(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *Handler) handleUserExtendedAccess(w http.ResponseWriter, req *http.Request) {
-	h.store.RLock()
-	defer h.store.RUnlock()
+	h.RLock()
+	defer h.RUnlock()
 	userID := chi.URLParam(req, "user_id")
 	require.NoError(h.t, req.ParseForm())
 	require.Equal(h.t, "project", req.Form.Get("filter[resource_type]"))
 	var (
-		projectGrants = make([]*UserGrant, 0, len(h.store.userGrants))
+		projectGrants = make([]*UserGrant, 0, len(h.userGrants))
 		projectIDs    = make(uniqueMap)
 		orgIDs        = make(uniqueMap)
 	)
-	for _, g := range h.store.userGrants {
+	for _, g := range h.userGrants {
 		if g.ResourceType == "project" && g.UserID == userID {
 			projectGrants = append(projectGrants, g)
 			projectIDs[g.ResourceID] = struct{}{}


### PR DESCRIPTION
Notes:

* The `migrate` command migrated the config (removing the comments)
* Local install is not obvious, they do not recommend `go install` or `go tool`, so the idea is you install golangci-lint globally (and v2 is not compatible with v1) - see https://golangci-lint.run/docs/welcome/install/#local-installation