### PR TITLE
Install the 'platform' binary by default

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 : "${GITHUB_TOKEN:=}"
 
 # Upsun CLI vendor to install
-: "${VENDOR:=upsun}"
+: "${VENDOR:=platform}"
 
 # CI specifics
 : "${CI:=}"


### PR DESCRIPTION
This otherwise breaks existing CI jobs of people using the "platform" binary across their script. Everyone can install the "upsun" binary by passing `| VENDOR=upsun bash` as before.